### PR TITLE
Migrate to getSchemaVersion(). Remove unused "Version" properties (al…

### DIFF
--- a/ApiKey/module.properties
+++ b/ApiKey/module.properties
@@ -3,4 +3,5 @@ License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ModuleClass: org.labkey.apikey.ApiKeyModule
 Name: ApiKey
+ManageVersion: false
 SupportedDatabases: pgsql

--- a/ApiKey/module.properties
+++ b/ApiKey/module.properties
@@ -3,5 +3,4 @@ License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ModuleClass: org.labkey.apikey.ApiKeyModule
 Name: ApiKey
-Version: 1.0
 SupportedDatabases: pgsql

--- a/ApiKey/src/org/labkey/apikey/ApiKeyModule.java
+++ b/ApiKey/src/org/labkey/apikey/ApiKeyModule.java
@@ -17,14 +17,13 @@
 package org.labkey.apikey;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.ldk.ExtendedSimpleModule;
-import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.apikey.api.ApiKeyService;
-import org.labkey.apikey.api.JsonService;
 import org.labkey.apikey.api.JsonServiceManager;
 import org.labkey.apikey.service.ApiKeyServiceImpl;
 import org.labkey.apikey.service.JsonServiceManagerImpl;
@@ -44,7 +43,7 @@ public class ApiKeyModule extends ExtendedSimpleModule
     }
 
     @Override
-    public double getVersion()
+    public @Nullable Double getSchemaVersion()
     {
         return 15.11;
     }

--- a/DBUtils/module.properties
+++ b/DBUtils/module.properties
@@ -4,4 +4,5 @@ ModuleDependencies: LDK, Study
 Name: DBUtils
 RequiredServerVersion: 16.3
 Version: 17.2
+ManageVersion: false
 SupportedDatabases: pgsql

--- a/DeviceProxy/module.properties
+++ b/DeviceProxy/module.properties
@@ -4,4 +4,5 @@ LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ModuleClass: org.labkey.deviceproxy.DeviceProxyModule
 ModuleDependencies: ApiKey
 Name: DeviceProxy
+ManageVersion: false
 SupportedDatabases: pgsql

--- a/DeviceProxy/module.properties
+++ b/DeviceProxy/module.properties
@@ -4,5 +4,4 @@ LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ModuleClass: org.labkey.deviceproxy.DeviceProxyModule
 ModuleDependencies: ApiKey
 Name: DeviceProxy
-Version: 1.0
 SupportedDatabases: pgsql

--- a/DeviceProxy/src/org/labkey/deviceproxy/DeviceProxyModule.java
+++ b/DeviceProxy/src/org/labkey/deviceproxy/DeviceProxyModule.java
@@ -1,10 +1,10 @@
 package org.labkey.deviceproxy;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.ldk.ExtendedSimpleModule;
-import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.view.WebPartFactory;
 
@@ -22,7 +22,7 @@ public class DeviceProxyModule extends ExtendedSimpleModule {
     }
 
     @Override
-    public double getVersion()
+    public @Nullable Double getSchemaVersion()
     {
         return 15.11;
     }

--- a/GoogleDrive/module.properties
+++ b/GoogleDrive/module.properties
@@ -8,4 +8,5 @@ Name: GoogleDrive
 RequiredServerVersion: 15.2
 URL: https://github.com/WNPRC-EHR-Services/GoogleDrive
 Version: 1.000
+ManageVersion: false
 SupportedDatabases: pgsql

--- a/WNPRC_Compliance/module.properties
+++ b/WNPRC_Compliance/module.properties
@@ -5,5 +5,5 @@ LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ModuleClass: org.labkey.wnprc_compliance.WNPRC_ComplianceModule
 ModuleDependencies: LDK, DBUtils, WebUtils
 Name: WNPRC_Compliance
-Version: 0.103
+Version: 20.000
 SupportedDatabases: pgsql

--- a/WNPRC_EHR/module.properties
+++ b/WNPRC_EHR/module.properties
@@ -2,4 +2,3 @@ ModuleClass: org.labkey.wnprc_ehr.WNPRC_EHRModule
 ModuleDependencies: EHR, LDK, WNPRC_Compliance, DBUtils, WebUtils, GoogleDrive, Viral_Load_Assay
 SupportedDatabases: pgsql
 Name: WNPRC_EHR
-Version: 15.13

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -17,6 +17,7 @@ package org.labkey.wnprc_ehr;
 
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -146,7 +147,8 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule {
         return NAME;
     }
 
-    public double getVersion() {
+    @Override
+    public @Nullable Double getSchemaVersion() {
         return forceUpdate ? Double.POSITIVE_INFINITY : 18.31;
     }
 

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -149,7 +149,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule {
 
     @Override
     public @Nullable Double getSchemaVersion() {
-        return forceUpdate ? Double.POSITIVE_INFINITY : 18.31;
+        return forceUpdate ? Double.POSITIVE_INFINITY : 20.000;
     }
 
     public boolean hasScripts() {

--- a/WebUtils/module.properties
+++ b/WebUtils/module.properties
@@ -4,4 +4,5 @@ Label: WNPRC WebUtils
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 Version: 17.2
+ManageVersion: false
 SupportedDatabases: pgsql

--- a/primateid/module.properties
+++ b/primateid/module.properties
@@ -5,4 +5,5 @@ License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ModuleDependencies: Study, Experiment, Query, LDK, EHR
 Version: 1.00
+ManageVersion: false
 SupportedDatabases: pgsql

--- a/wnprc_billing/src/org/labkey/wnprc_billing/WNPRC_BillingModule.java
+++ b/wnprc_billing/src/org/labkey/wnprc_billing/WNPRC_BillingModule.java
@@ -63,7 +63,7 @@ public class WNPRC_BillingModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 18.30;
+        return 20.000;
     }
 
     @Override

--- a/wnprc_billing/src/org/labkey/wnprc_billing/WNPRC_BillingModule.java
+++ b/wnprc_billing/src/org/labkey/wnprc_billing/WNPRC_BillingModule.java
@@ -17,6 +17,7 @@
 package org.labkey.wnprc_billing;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.ehr.EHRService;
@@ -60,7 +61,7 @@ public class WNPRC_BillingModule extends ExtendedSimpleModule
     }
 
     @Override
-    public double getVersion()
+    public @Nullable Double getSchemaVersion()
     {
         return 18.30;
     }

--- a/wnprc_billingpublic/module.properties
+++ b/wnprc_billingpublic/module.properties
@@ -1,3 +1,2 @@
 Name: WNPRC_BillingPublic
-Version: 18.30
 SupportedDatabases: pgsql


### PR DESCRIPTION
…l are overridden by getSchemaVersion()).