### PR TITLE
Move registration to init() to avoid error during startup

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -159,6 +159,9 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule {
     protected void init() {
         TissueSampleTable.registerProperties();
         addController(CONTROLLER_NAME, WNPRC_EHRController.class);
+
+        registerRoles();
+        registerPermissions();
     }
 
     @Override
@@ -224,8 +227,6 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule {
 
         EHRService.get().registerLabworkType(new WNPRCUrinalysisLabworkType(this));
 
-        this.registerRoles();
-        this.registerPermissions();
 
         BCReportRunner.schedule();
 


### PR DESCRIPTION
https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_EhrPostgres/959234?buildTab=artifacts

If first request comes in before module startup is complete, error is logged about not knowing about a permission