### PR TITLE
Turn off "warnings as errors" settings

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -40,12 +40,12 @@ configurations {
 
 //TODO: Check where are warning in the ApiKey, DeviceProxy and DbUtils 
 //      the following lines are commented temporary to allow compiling in TeamCity 
-tasks.compileApiJava {
-    options.compilerArgs << '-Werror'
-}
-tasks.compileJava {
-    options.compilerArgs << "-Werror"
-}
+//tasks.compileApiJava {
+//    options.compilerArgs << '-Werror'
+//}
+//tasks.compileJava {
+//    options.compilerArgs << "-Werror"
+//}
 
 dependencies {
     apiCompile 'org.jetbrains:annotations:15.0'


### PR DESCRIPTION
#### Rationale
Strict -Werror compile options in wnprc build are causing unnecessary failures in the standard verify build.
