### PR TITLE
Update api and internal packages to gradle 7-compatible configurations

### DIFF
--- a/ApiKey/build.gradle
+++ b/ApiKey/build.gradle
@@ -1,11 +1,11 @@
 import org.labkey.gradle.util.BuildUtils
 
 dependencies {
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiCompile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 
     apiExternal "org.apache.commons:commons-collections4:${commonsCollections4Version}"
-    compile "javax.servlet:jsp-api:2.0"
-    compile files(apiJar)
+    implementation "javax.servlet:jsp-api:2.0"
+    implementation files(apiJar)
     external "org.jooq:jooq:3.8.4"
     external "javax.xml.bind:jaxb-api:${jaxbVersion}"
 }

--- a/DBUtils/build.gradle
+++ b/DBUtils/build.gradle
@@ -2,10 +2,10 @@ import org.labkey.gradle.util.BuildUtils
 
 dependencies {
 
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiCompile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 
-    apiCompile "com.google.guava:guava:17.0"
-    compile project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"))
+    apiImplementation "com.google.guava:guava:17.0"
+    implementation project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"))
     external "org.jooq:jooq:3.8.4"
     external "javax.xml.bind:jaxb-api:${jaxbVersion}"
 }

--- a/DeviceProxy/build.gradle
+++ b/DeviceProxy/build.gradle
@@ -1,10 +1,10 @@
 import org.labkey.gradle.util.BuildUtils
 
 dependencies {
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiCompile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 
-    compile "javax.servlet:jsp-api:2.0"
-    compile project(path: "${project.parent.path}:ApiKey", configuration: "apiCompile")
+    implementation "javax.servlet:jsp-api:2.0"
+    implementation project(path: "${project.parent.path}:ApiKey", configuration: "apiCompile")
     external "org.jooq:jooq:3.8.4"
     external "javax.xml.bind:jaxb-api:${jaxbVersion}"
 }

--- a/GoogleDrive/build.gradle
+++ b/GoogleDrive/build.gradle
@@ -1,14 +1,14 @@
 import org.labkey.gradle.util.BuildUtils
 
 dependencies {
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiCompile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 
-    compile project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"))
-    compile project(path: "${project.parent.path}:DBUtils",  configuration: "apiCompile")
-    compile project("${project.parent.path}:WebUtils")
-    compile files(apiJar)
+    implementation project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"))
+    implementation project(path: "${project.parent.path}:DBUtils",  configuration: "apiJarFile")
+    implementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
+    implementation files(apiJar)
     external 'com.google.api-client:google-api-client:1.22.0'
     external 'com.google.apis:google-api-services-drive:v3-rev85-1.23.0'
-    jspCompile project(BuildUtils.getApiProjectPath(project.gradle))
-    jspCompile project("${project.parent.path}:WebUtils")
+    jspImplementation project(BuildUtils.getApiProjectPath(project.gradle))
+    jspImplementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
 }

--- a/WNPRC_Compliance/build.gradle
+++ b/WNPRC_Compliance/build.gradle
@@ -1,16 +1,16 @@
 import org.labkey.gradle.util.BuildUtils
 
 dependencies {
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiCompile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 
-    compile project(path: "${project.parent.path}:DBUtils", configuration: "apiCompile")
-    compile project("${project.parent.path}:DBUtils")
-    compile project("${project.parent.path}:WebUtils")
-    compile "javax.servlet:jsp-api:2.0"
+    implementation project(path: "${project.parent.path}:DBUtils", configuration: "apiJarFile")
+    implementation project("${project.parent.path}:DBUtils")
+    implementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
+    implementation "javax.servlet:jsp-api:2.0"
     external "org.jooq:jooq:3.8.4"
     external "org.apache.pdfbox:pdfbox:${pdfboxVersion}"
-    jspCompile project("${project.parent.path}:WebUtils")
-    jspCompile project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"))
+    jspImplementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
+    jspImplementation project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"))
 }
 
 sourceSets {

--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -1,7 +1,5 @@
 import org.labkey.gradle.util.BuildUtils
 
-apply plugin: 'org.labkey.npmRun'
-
 dependencies {
     implementation project(BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"))
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")

--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -1,17 +1,19 @@
 import org.labkey.gradle.util.BuildUtils
 
+apply plugin: 'org.labkey.npmRun'
+
 dependencies {
     implementation project(BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"))
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
     implementation project(path: "${project.parent.path}:DBUtils", configuration: "apiJarFile")
-    implementation project("${project.parent.path}:WebUtils")
+    implementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
     implementation project(path: "${project.parent.path}:GoogleDrive", configuration: "apiJarFile")
     external "joda-time:joda-time:2.8.1"
     external "org.jsoup:jsoup:1.10.3"
     external "org.reflections:reflections:0.9.10"
     jspImplementation project(path: "${project.parent.path}:DBUtils",  configuration: "apiJarFile")
-    jspImplementation project("${project.parent.path}:WebUtils")
+    jspImplementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
     jspImplementation "joda-time:joda-time:2.8.1"
 }
 configurations.all {

--- a/WebUtils/build.gradle
+++ b/WebUtils/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+    apiImplementation "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"
     compile project(path: "${project.parent.path}:WebUtils", configuration: "apiCompile")
     compile "javax.servlet:jsp-api:2.0"
+    apiImplementation "javax.servlet:jsp-api:2.0"
 }

--- a/WebUtils/build.gradle
+++ b/WebUtils/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     apiImplementation "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"
-    compile project(path: "${project.parent.path}:WebUtils", configuration: "apiCompile")
-    compile "javax.servlet:jsp-api:2.0"
+    implementation "javax.servlet:jsp-api:2.0"
     apiImplementation "javax.servlet:jsp-api:2.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ import org.labkey.gradle.util.BuildUtils
  **********************************************************************************************************************/
 
 // using this to manage our node_modules and package.json in the base directory rather than module by module
-apply plugin: 'com.github.node-gradle.node'
+apply plugin: 'org.labkey.npmRun'
 
 // using this to ignore the node_modules and other "base" folders in IntelliJ IDEA
 apply plugin: 'idea'

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -33,9 +33,9 @@ sourceSets {
 
 configurations {
     apiExternal
-    apiCompile.extendsFrom(apiExternal)
+    apiImplementation.extendsFrom(apiExternal)
     external
-    compile.extendsFrom(external)
+    implementation.extendsFrom(external)
 }
 
 //TODO: Check where are warning in the ApiKey, DeviceProxy and DbUtils 
@@ -48,16 +48,16 @@ configurations {
 //}
 
 dependencies {
-    apiCompile 'org.jetbrains:annotations:15.0'
-    apiCompile project(BuildUtils.getApiProjectPath(project.gradle))
-    apiCompile project(":server:modules:wnprc-modules:java2ts")
+    apiImplementation 'org.jetbrains:annotations:15.0'
+    apiImplementation project(BuildUtils.getApiProjectPath(project.gradle))
+    apiImplementation project(":server:modules:wnprc-modules:java2ts")
 
-    compile 'org.jetbrains:annotations:15.0'
-    compile "junit:junit:${junitVersion}"
-    compile project(BuildUtils.getApiProjectPath(project.gradle))
-    compile project(BuildUtils.getInternalProjectPath(project.gradle))
-    compile project(":server:modules:LabDevKitModules:LDK")
-    compile project(":server:modules:wnprc-modules:java2ts")
+    implementation 'org.jetbrains:annotations:15.0'
+    implementation "junit:junit:${junitVersion}"
+    implementation project(BuildUtils.getApiProjectPath(project.gradle))
+    implementation project(BuildUtils.getInternalProjectPath(project.gradle))
+    implementation project(":server:modules:LabDevKitModules:LDK")
+    implementation project(":server:modules:wnprc-modules:java2ts")
 }
 
 project.evaluationDependsOn(BuildUtils.getInternalProjectPath(project.gradle))

--- a/gradle/javascript.gradle
+++ b/gradle/javascript.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'com.github.node-gradle.node'
+apply plugin: 'org.labkey.npmRun'
 
 if (file("${project.projectDir}/src/java").exists())
 {
@@ -25,7 +25,9 @@ if (file("$projectDir/webpack.config.js").exists() || file("$projectDir/webpack.
 {
     task('webpack', group: 'JavaScript', type: NodeTask, dependsOn: ["${project.parent.path}:npmInstall"],
             description: 'Executes webpack to compile the TypeScript and create a self-contained JavaScript bundle') {
-        workingDir "$projectDir"
+        execOverrides {
+            it.workingDir "$projectDir"
+        }
         script = file('../node_modules/webpack/bin/webpack.js')
         args   = ['--env.BUILD_DIR', "$buildDir", '--env.PROJECT_DIR', "$projectDir"]
         if (project.tasks.findByName('java2ts'))

--- a/java2ts/build.gradle
+++ b/java2ts/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'java'
 
 dependencies {
-    compile "org.jtwig:jtwig-core:5.86.1.RELEASE"
-    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
-    compile "commons-io:commons-io:${commonsIoVersion}"
-    runtime "org.slf4j:slf4j-simple:${slf4jLog4j12Version}"
-    testCompile "junit:junit:${junitVersion}"
+    implementation "org.jtwig:jtwig-core:5.86.1.RELEASE"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation "commons-io:commons-io:${commonsIoVersion}"
+    runtimeOnly "org.slf4j:slf4j-simple:${slf4jLog4j12Version}"
+    testImplementation "junit:junit:${junitVersion}"
 }

--- a/primateid/build.gradle
+++ b/primateid/build.gradle
@@ -1,8 +1,10 @@
 import org.labkey.gradle.util.BuildUtils
 
+apply plugin: 'org.labkey.npmRun'
+
 dependencies {
-    compile project(":server:modules:ehrModules:ehr")
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiCompile")
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiCompile")
+    implementation project(":server:modules:ehrModules:ehr")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
 
 }

--- a/primateid/build.gradle
+++ b/primateid/build.gradle
@@ -1,7 +1,5 @@
 import org.labkey.gradle.util.BuildUtils
 
-apply plugin: 'org.labkey.npmRun'
-
 dependencies {
     implementation project(":server:modules:ehrModules:ehr")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")

--- a/wnprc_billing/build.gradle
+++ b/wnprc_billing/build.gradle
@@ -1,13 +1,13 @@
-import org.labkey.gradle.util.BuildUtils;
+import org.labkey.gradle.util.BuildUtils
 
 dependencies {
     external "com.koadweb.javafpdf:java-fpdf:${javafpdfVersion}"
     external("org.apache.sanselan:sanselan:${sanselanVersion}")
 
 
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:ehrModules:ehr_billing", depProjectConfig: "apiCompile")
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiCompile")
-    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiCompile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr_billing", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 }
 
 sourceSets {


### PR DESCRIPTION
#### Rationale
When updating the api and internal modules to remove use of the deprecated compile configuration, we expose some missing dependency declarations for other modules.  Previously, these dependencies were leaking through from the api module, so we need to declare explicit dependencies when they are not actually a result of reliance on api.

We also take the opportunity here to remove references to deprecated compile and runtime configurations here and attempt to fix the issue that required npm to be on the path when building these modules.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1247

#### Changes
* Convert from compile configurations to implementation configurations
* Convert from runtime configuration to runtimeOnly configuration
* Issue 39721: Use `org.labkey.npmRun` plugin in order to get the needed configuration for using the gradle-installed npm and node binaries
* Add dependencies that are no longer leaking out of the api module
