### PR TITLE
Remove last(?) apiCompile reference

### DIFF
--- a/DeviceProxy/build.gradle
+++ b/DeviceProxy/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 
     implementation "javax.servlet:jsp-api:2.0"
-    implementation project(path: "${project.parent.path}:ApiKey", configuration: "apiCompile")
+    implementation project(path: "${project.parent.path}:ApiKey", configuration: "apiJarFile")
     external "org.jooq:jooq:3.8.4"
     external "javax.xml.bind:jaxb-api:${jaxbVersion}"
 }


### PR DESCRIPTION
#### Rationale
`apiCompile` is deprecated and will result in an error for Gradle 7.  We use `apiJarFile` instead.