### PR TITLE
Reconcile dependency versions

### DIFF
--- a/Gringotts/build.gradle
+++ b/Gringotts/build.gradle
@@ -6,10 +6,10 @@ dependencies {
 
     apiExternal "xerces:xercesImpl:${xercesImplVersion}"
     apiExternal "org.apache.commons:commons-collections4:${commonsCollections4Version}"
-    apiExternal "joda-time:joda-time:2.9.3"
+    apiExternal "joda-time:joda-time:2.8.1"
     compile "javax.servlet:jsp-api:2.0"
     compile files(apiJar)
     external "org.jooq:jooq:3.8.4"
     external "org.apache.commons:commons-collections4:${commonsCollections4Version}"
-    external "joda-time:joda-time:2.9.3"
+    external "joda-time:joda-time:2.8.1"
 }

--- a/Gringotts/resources/credits/jars.txt
+++ b/Gringotts/resources/credits/jars.txt
@@ -1,6 +1,6 @@
 {table}
 Filename|Component|Version|Source|License|LabKey Dev|Purpose
 commons-collections4-4.1.jar|Apache Commons Collections|4.1|{link:From Apache|https://git-wip-us.apache.org/repos/asf?p=commons-collections.git}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Tools for managing Java collections
-joda-time-2.9.3.jar|Joda-Time|2.9.3|{link:From GitHub|https://github.com/JodaOrg/joda-time}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Tools for dealing with dates/times in Java
+joda-time-2.8.1.jar|Joda-Time|2.8.1|{link:From GitHub|https://github.com/JodaOrg/joda-time}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Tools for dealing with dates/times in Java
 jooq-3.8.4.jar|jOOQ|3.8.4|{link:From GitHub|https://github.com/jOOQ/jOOQ}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Database-mapping for Java
 {table}

--- a/WNPRC_EHR/resources/credits/jars.txt
+++ b/WNPRC_EHR/resources/credits/jars.txt
@@ -1,6 +1,6 @@
 {table}
 Filename|Component|Version|Source|License|LabKey Dev|Purpose
-joda-time-2.9.3.jar|Joda-Time|2.9.3|{link:From GitHub|https://github.com/JodaOrg/joda-time}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Tools for dealing with dates/times in Java
+joda-time-2.8.1.jar|Joda-Time|2.8.1|{link:From GitHub|https://github.com/JodaOrg/joda-time}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Tools for dealing with dates/times in Java
 jsoup-1.10.3.jar|jsoup: Java HTML Parser|1.10.3|{link:From GitHub|https://github.com/jhy/jsoup}|{link:MIT License|https://opensource.org/licenses/MIT}|jricharson|Tools for parsing and manipulating HTML and CSS using the DOM
 reflections-0.9.10.jar|Reflections|0.9.10|{link:From GitHub|https://github.com/ronmamo/reflections}|{link:WTFPL|http://www.wtfpl.net/about/}|cstevens|Runtime analysis of Java classes and packages
 {table}


### PR DESCRIPTION
#### Rationale
We have competing version of joda-time being pulled in

#### Changes
* Consolidate on 2.8.1 to eliminate the discrepancy