### PR TITLE
Use q(URLHelper). Simplify URL creation using urlFor().

### DIFF
--- a/GoogleDrive/src/org/labkey/googledrive/view/RegisterServiceAccount.jsp
+++ b/GoogleDrive/src/org/labkey/googledrive/view/RegisterServiceAccount.jsp
@@ -160,7 +160,7 @@
             delete data.type;
             data.displayName = form.displayName();
 
-            WebUtils.API.postJSON(<%=q(apiURL.toString())%>, data).then(function() {
+            WebUtils.API.postJSON(<%=q(apiURL)%>, data).then(function() {
                 alert("Success");
                 window.location = <%=q(manageURL)%>;
             }).catch(function(e) {

--- a/WNPRC_Compliance/src/org/labkey/wnprc_compliance/view/enterTB.jsp
+++ b/WNPRC_Compliance/src/org/labkey/wnprc_compliance/view/enterTB.jsp
@@ -1,9 +1,12 @@
 <%@ page import="org.labkey.api.view.ActionURL" %>
-<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController" %>
+<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController.BeginAction" %>
+<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController.NewUserAPI" %>
+<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController.SearchUserAPI" %>
+<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController.UpdatePersonClearanceAPI" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%
-    ActionURL url = new ActionURL(WNPRC_ComplianceController.BeginAction.class, getContainer());
+    ActionURL url = urlFor(BeginAction.class);
 %>
 <div class="text-center" style="margin-bottom: 10px;">
     <a class="btn btn-primary" href="<%=h(url)%>">
@@ -364,7 +367,7 @@
         };
 
         <%
-            ActionURL searchQuery = new ActionURL(WNPRC_ComplianceController.SearchUserAPI.class, getContainer());
+            ActionURL searchQuery = urlFor(SearchUserAPI.class);
         %>
 
         VM.searchTerm.subscribe(function(query) {
@@ -475,7 +478,7 @@
             var form = ko.mapping.toJS(VM.newUserForm);
 
             if (VM.createNewUser() == 'yes') {
-                submission.url = <%=q(new ActionURL(WNPRC_ComplianceController.NewUserAPI.class, getContainer()).toString())%>;
+                submission.url = <%=q(urlFor(NewUserAPI.class))%>;
 
                 submission.data = {
                     firstName:   form.firstName,
@@ -503,7 +506,7 @@
                 }
             }
             else {
-                submission.url = <%=q(new ActionURL(WNPRC_ComplianceController.UpdatePersonClearanceAPI.class, getContainer()).toString())%>;
+                submission.url = <%=q(urlFor(UpdatePersonClearanceAPI.class))%>;
 
                 submission.data = {
                     personid: VM.selectedPerson()

--- a/WNPRC_Compliance/src/org/labkey/wnprc_compliance/view/pendingTBResults.jsp
+++ b/WNPRC_Compliance/src/org/labkey/wnprc_compliance/view/pendingTBResults.jsp
@@ -1,10 +1,11 @@
 <%@ page import="org.labkey.api.view.ActionURL" %>
-<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController" %>
+<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController.BeginAction" %>
+<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController.ResolvePendingTBResultsAPI" %>
 <%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceSchema" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%
-    ActionURL url = new ActionURL(WNPRC_ComplianceController.BeginAction.class, getContainer());
+    ActionURL url = urlFor(BeginAction.class);
 %>
 <div class="text-center" style="margin-bottom: 10px;">
     <a class="btn btn-primary" href="<%=h(url)%>">
@@ -92,7 +93,7 @@
         WebUtils.VM.submit = function() {
             $resultDialog.modal('hide');
 
-            WebUtils.API.postJSON(<%=q(new ActionURL(WNPRC_ComplianceController.ResolvePendingTBResultsAPI.class, getContainer()).toString())%>, {
+            WebUtils.API.postJSON(<%=q(urlFor(ResolvePendingTBResultsAPI.class))%>, {
                 pendingTBIds: form.selectedTBIds(),
                 notes: form.notes(),
                 date:  moment(form.date()).format()

--- a/WNPRC_Compliance/src/org/labkey/wnprc_compliance/view/unidentifiedCards.jsp
+++ b/WNPRC_Compliance/src/org/labkey/wnprc_compliance/view/unidentifiedCards.jsp
@@ -1,10 +1,11 @@
 <%@ page import="org.labkey.api.view.ActionURL" %>
-<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController" %>
+<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController.BeginAction" %>
+<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController.MarkCardExemptAPI" %>
 <%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceSchema" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%
-    ActionURL url = (new ActionURL(WNPRC_ComplianceController.BeginAction.class, getContainer()));
+    ActionURL url = urlFor(BeginAction.class);
 %>
 <div class="text-center" style="margin-bottom: 10px;">
     <a class="btn btn-primary" href="<%=h(url)%>">
@@ -82,7 +83,7 @@
         WebUtils.VM.submit = function() {
             $exemptDialog.modal('hide');
 
-            WebUtils.API.postJSON(<%=q(new ActionURL(WNPRC_ComplianceController.MarkCardExemptAPI.class, getContainer()).toString())%>, {
+            WebUtils.API.postJSON(<%=q(urlFor(MarkCardExemptAPI.class))%>, {
                 exemptions: form.selectedCardIds().map(function(id) {
                     return {
                         cardId: id,

--- a/WNPRC_Compliance/src/org/labkey/wnprc_compliance/view/uploadAccessReport.jsp
+++ b/WNPRC_Compliance/src/org/labkey/wnprc_compliance/view/uploadAccessReport.jsp
@@ -1,9 +1,10 @@
 <%@ page import="org.labkey.api.view.ActionURL" %>
-<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController" %>
+<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController.BeginAction" %>
+<%@ page import="org.labkey.wnprc_compliance.WNPRC_ComplianceController.UploadAccessReportAPI" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%
-    ActionURL url = new ActionURL(WNPRC_ComplianceController.BeginAction.class, getContainer());
+    ActionURL url = urlFor(BeginAction.class);
 %>
 <div class="text-center" style="margin-bottom: 10px;">
     <a class="btn btn-primary" href="<%=h(url)%>">
@@ -39,7 +40,7 @@
     (function() {
 
         var dropZone = jQuery("#access-report-upload").dropzone({
-            url: <%=q(new ActionURL(WNPRC_ComplianceController.UploadAccessReportAPI.class, getContainer()).toString())%>,
+            url: <%=q(urlFor(UploadAccessReportAPI.class))%>,
             method: "post",
             maxFiles: 1,
             init: function() {

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/dataentry/behavior/AssignBehaviorProjects.jsp
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/dataentry/behavior/AssignBehaviorProjects.jsp
@@ -409,7 +409,7 @@
                     }
                 });
 
-                WebUtils.API.post(<%=q(releaseAnimalURL.toString())%>, data).then(function() {
+                WebUtils.API.post(<%=q(releaseAnimalURL)%>, data).then(function() {
                     WebUtils.VM.refreshCurrentAssignmentsTable();
                     toastr.success(data.animalId + " successfully released from behavior project.");
                 }).catch(function(e) {
@@ -576,7 +576,7 @@
             };
 
             console.log("Submitting data: ", dataToSubmit);
-            WebUtils.API.postJSON(<%=q(addBehaviorURL.toString())%>, dataToSubmit).then(function() {
+            WebUtils.API.postJSON(<%=q(addBehaviorURL)%>, dataToSubmit).then(function() {
                 WebUtils.VM.refreshCurrentAssignmentsTable();
                 WebUtils.VM.form.clearForm();
                 toastr.success("Assignment successfully added.");


### PR DESCRIPTION
#### Rationale
Use `q(URLHelper)`. Simplify URL creation using `urlFor()`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1549
