### PR TITLE
Adjust all JSPs to extend JspContext

### DIFF
--- a/WNPRC_Compliance/src/org/labkey/wnprc_compliance/view/exemptCards.jsp
+++ b/WNPRC_Compliance/src/org/labkey/wnprc_compliance/view/exemptCards.jsp
@@ -1,0 +1,1 @@
+<%@ page extends="org.labkey.api.jsp.JspContext" %>

--- a/WebUtils/src/org/labkey/webutils/view/JspReport.jsp
+++ b/WebUtils/src/org/labkey/webutils/view/JspReport.jsp
@@ -1,0 +1,1 @@
+<%@ page extends="org.labkey.api.jsp.JspContext" %>


### PR DESCRIPTION
#### Rationale
All JSPs need to extend `JspContext`. Or maybe these empty JSPs should be deleted.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1564