### PR TITLE
Switch to DisplayColumn.getFormattedHtml() and use HtmlString

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/query/ViralAssayCustomizer.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/query/ViralAssayCustomizer.java
@@ -16,6 +16,7 @@ import org.labkey.api.ldk.table.ButtonConfigFactory;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.util.HtmlString;
 
 import java.util.List;
 
@@ -216,8 +217,8 @@ public class ViralAssayCustomizer implements TableCustomizer {
         }
 
         @Override
-        public String getFormattedValue(RenderContext ctx) {
-            return h(getValue(ctx));
+        public HtmlString getFormattedHtml(RenderContext ctx) {
+            return HtmlString.of(getValue(ctx));
         }
     }
 

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/query/ViralLoadUnitsDisplayColumnFactory.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/query/ViralLoadUnitsDisplayColumnFactory.java
@@ -5,6 +5,7 @@ import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
+import org.labkey.api.util.HtmlString;
 
 public class ViralLoadUnitsDisplayColumnFactory implements DisplayColumnFactory
 {
@@ -40,8 +41,8 @@ public class ViralLoadUnitsDisplayColumnFactory implements DisplayColumnFactory
         }
 
         @Override
-        public String getFormattedValue(RenderContext ctx) {
-            return h(getValue(ctx));
+        public HtmlString getFormattedHtml(RenderContext ctx) {
+            return HtmlString.of(getValue(ctx));
         }
     }
 }


### PR DESCRIPTION
#### Rationale
Switch to using HtmlString when rendering a grid or details value to ensure proper encoding. Fix up many problematic subclasses.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1602

#### Changes
* Remove deprecated getFormattedValue(), consolidate on getFormattedHtml()
* Use HtmlString to signal this is specifically for HTML