### PR TITLE
Register 'iStatLabworkType' and 'DefaultClinicalRemarksDataSource' - change part of onprc19.1 svn merge r.63271

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -249,6 +249,8 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
         EHRService.get().registerHistoryDataSource(new DefaultAlopeciaDataSource(this));
         EHRService.get().registerHistoryDataSource(new DefaultBodyConditionDataSource(this));
         EHRService.get().registerHistoryDataSource(new DefaultTBDataSource(this));
+        EHRService.get().registerHistoryDataSource(new DefaultClinicalRemarksDataSource(module));
+        EHRService.get().registerLabworkType(new iStatLabworkType(module));
 
         EHRService.get().addModuleRequiringLegacyExt3EditUI(this);
 

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -32,6 +32,8 @@ import org.labkey.api.ehr.security.EHRStartedAdminPermission;
 import org.labkey.api.ehr.security.EHRStartedDeletePermission;
 import org.labkey.api.ehr.security.EHRStartedInsertPermission;
 import org.labkey.api.ehr.security.EHRStartedUpdatePermission;
+import org.labkey.api.ehr.history.DefaultClinicalRemarksDataSource;
+import org.labkey.api.ehr.history.iStatLabworkType;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
 import org.labkey.api.ldk.ExtendedSimpleModule;
 import org.labkey.api.ldk.notification.Notification;
@@ -249,8 +251,8 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
         EHRService.get().registerHistoryDataSource(new DefaultAlopeciaDataSource(this));
         EHRService.get().registerHistoryDataSource(new DefaultBodyConditionDataSource(this));
         EHRService.get().registerHistoryDataSource(new DefaultTBDataSource(this));
-        EHRService.get().registerHistoryDataSource(new DefaultClinicalRemarksDataSource(module));
-        EHRService.get().registerLabworkType(new iStatLabworkType(module));
+        EHRService.get().registerHistoryDataSource(new DefaultClinicalRemarksDataSource(this));
+        EHRService.get().registerLabworkType(new iStatLabworkType(this));
 
         EHRService.get().addModuleRequiringLegacyExt3EditUI(this);
 


### PR DESCRIPTION
#### Rationale
Registration of 'iStatLabworkType' and 'DefaultClinicalRemarksDataSource' were removed from EHR module as part of onprc19.1 merge r.63271

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1626
https://github.com/LabKey/ehrModules/pull/74
https://github.com/LabKey/onprcEHRModules/pull/32
https://github.com/LabKey/DiscvrLabKeyModules/pull/64
https://github.com/LabKey/LabDevKitModules/pull/55
https://github.com/LabKey/sampleManagement/pull/381
https://github.com/LabKey/biologics/pull/712
https://github.com/LabKey/labbook/pull/53

#### Changes
Register 'iStatLabworkType' and 'DefaultClinicalRemarksDataSource' in wnprc module