### PR TITLE
Add missing module dependencies and move dependencies declarations out of module.properties files

### DIFF
--- a/AnimalRequests/build.gradle
+++ b/AnimalRequests/build.gradle
@@ -1,3 +1,5 @@
+import org.labkey.gradle.util.BuildUtils
+
 apply plugin: 'java'
 apply plugin: 'org.labkey.module'
 compileJava {
@@ -8,6 +10,8 @@ compileJava {
 dependencies {
 //    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":server:modules:wnprc-modules:WNPRC_EHR", depProjectConfig: "apiCompile")
     implementation project(":server:modules:wnprc-modules:WNPRC_EHR")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:wnprc-modules:WNPRC_EHR", depProjectConfig: "published", depExtension: "module")
+
 }
 
 // This is added to eliminate the possibility of a race condition between these two npmInstalls.

--- a/AnimalRequests/module.properties
+++ b/AnimalRequests/module.properties
@@ -1,5 +1,4 @@
 ModuleClass: org.labkey.animalrequests.AnimalRequestsModule
-ModuleDependencies: WNPRC_EHR
 Label: Enter Animal Requests into EHR
 Description: Simple module that utilizes React and Typescript to enter animal requests into WNPRC EHR
 URL: https://github.com/WNPRC-EHR-Services/wnprc-modules/AnimalRequests

--- a/ApiKey/build.gradle
+++ b/ApiKey/build.gradle
@@ -2,6 +2,7 @@ import org.labkey.gradle.util.BuildUtils
 
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
 
     apiExternal "org.apache.commons:commons-collections4:${commonsCollections4Version}"
     implementation "javax.servlet:jsp-api:2.0"

--- a/DBUtils/build.gradle
+++ b/DBUtils/build.gradle
@@ -3,6 +3,8 @@ import org.labkey.gradle.util.BuildUtils
 dependencies {
 
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: 'published', depExtension: 'module')
 
     apiImplementation "com.google.guava:guava:17.0"
     implementation project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"))

--- a/DBUtils/module.properties
+++ b/DBUtils/module.properties
@@ -1,6 +1,5 @@
 Label: WNPRC Database Utility Module
 ModuleClass: org.labkey.dbutils.dbutilsModule
-ModuleDependencies: LDK, Study
 Name: DBUtils
 RequiredServerVersion: 16.3
 SchemaVersion: 17.2

--- a/DeviceProxy/build.gradle
+++ b/DeviceProxy/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:wnprc-modules:ApiKey", depProjectConfig: 'published', depExtension: 'module')
 
     implementation "javax.servlet:jsp-api:2.0"
-    labkey project(path: "${project.parent.path}:ApiKey", configuration: "apiJarFile")
+    implementation project(path: "${project.parent.path}:ApiKey", configuration: "apiJarFile")
     external "org.jooq:jooq:3.8.4"
     external "javax.xml.bind:jaxb-api:${jaxbVersion}"
 }

--- a/DeviceProxy/build.gradle
+++ b/DeviceProxy/build.gradle
@@ -2,9 +2,11 @@ import org.labkey.gradle.util.BuildUtils
 
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:wnprc-modules:ApiKey", depProjectConfig: 'published', depExtension: 'module')
 
     implementation "javax.servlet:jsp-api:2.0"
-    implementation project(path: "${project.parent.path}:ApiKey", configuration: "apiJarFile")
+    labkey project(path: "${project.parent.path}:ApiKey", configuration: "apiJarFile")
     external "org.jooq:jooq:3.8.4"
     external "javax.xml.bind:jaxb-api:${jaxbVersion}"
 }

--- a/DeviceProxy/module.properties
+++ b/DeviceProxy/module.properties
@@ -2,7 +2,6 @@ Label: WNPRC DeviceProxy Helper
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ModuleClass: org.labkey.deviceproxy.DeviceProxyModule
-ModuleDependencies: ApiKey
 Name: DeviceProxy
 ManageVersion: false
 SupportedDatabases: pgsql

--- a/ETLChemistryAnalyzer/build.gradle
+++ b/ETLChemistryAnalyzer/build.gradle
@@ -6,5 +6,5 @@ compileJava {
 }
 
 dependencies {
-    compile project(":server:modules:wnprc-modules:WNPRC_EHR")
+    implementation project(":server:modules:wnprc-modules:WNPRC_EHR")
 }

--- a/GoogleDrive/build.gradle
+++ b/GoogleDrive/build.gradle
@@ -2,9 +2,6 @@ import org.labkey.gradle.util.BuildUtils
 
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
-    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
-    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:DBUtils", depProjectConfig: 'published', depExtension: 'module')
-    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:WebUtils", depProjectConfig: 'published', depExtension: 'module')
 
     implementation project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"))
     implementation project(path: "${project.parent.path}:DBUtils",  configuration: "apiJarFile")
@@ -14,4 +11,10 @@ dependencies {
     external 'com.google.apis:google-api-services-drive:v3-rev85-1.23.0'
     jspImplementation project(BuildUtils.getApiProjectPath(project.gradle))
     jspImplementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
+
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"), depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:DBUtils", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:WebUtils", depProjectConfig: 'published', depExtension: 'module')
+
 }

--- a/GoogleDrive/build.gradle
+++ b/GoogleDrive/build.gradle
@@ -2,6 +2,9 @@ import org.labkey.gradle.util.BuildUtils
 
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:DBUtils", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:WebUtils", depProjectConfig: 'published', depExtension: 'module')
 
     implementation project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"))
     implementation project(path: "${project.parent.path}:DBUtils",  configuration: "apiJarFile")

--- a/GoogleDrive/module.properties
+++ b/GoogleDrive/module.properties
@@ -3,7 +3,6 @@ Label: Allows easy access to Google Drive for storage
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ModuleClass: org.labkey.googledrive.GoogleDriveModule
-ModuleDependencies: Query, DBUtils, WebUtils
 Name: GoogleDrive
 RequiredServerVersion: 15.2
 URL: https://github.com/WNPRC-EHR-Services/GoogleDrive

--- a/Gringotts/build.gradle
+++ b/Gringotts/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     apiExternal "xerces:xercesImpl:${xercesImplVersion}"
     apiExternal "org.apache.commons:commons-collections4:${commonsCollections4Version}"
     apiExternal "joda-time:joda-time:2.8.1"
-    compile "javax.servlet:jsp-api:2.0"
-    compile files(apiJar)
+    implementation "javax.servlet:jsp-api:2.0"
+    implementation files(apiJar)
     external "org.jooq:jooq:3.8.4"
     external "org.apache.commons:commons-collections4:${commonsCollections4Version}"
     external "joda-time:joda-time:2.8.1"

--- a/Gringotts/build.gradle
+++ b/Gringotts/build.gradle
@@ -3,6 +3,7 @@ import org.labkey.gradle.util.BuildUtils
 dependencies {
 
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
 
     apiExternal "xerces:xercesImpl:${xercesImplVersion}"
     apiExternal "org.apache.commons:commons-collections4:${commonsCollections4Version}"

--- a/Gringotts/module.properties
+++ b/Gringotts/module.properties
@@ -3,6 +3,5 @@ License: Apache 2.0
 SupportedDatabases: pgsql
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ModuleClass: org.labkey.gringotts.GringottsModule
-ModuleDependencies: LDK
 Name: Gringotts
 Version: 1.0

--- a/WNPRC_Compliance/build.gradle
+++ b/WNPRC_Compliance/build.gradle
@@ -11,6 +11,11 @@ dependencies {
     external "org.apache.pdfbox:pdfbox:${pdfboxVersion}"
     jspImplementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
     jspImplementation project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"))
+
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:wnprc-modules:DBUtils", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:wnprc-modules:WebUtils", depProjectConfig: "published", depExtension: "module")
+
 }
 
 sourceSets {

--- a/WNPRC_Compliance/module.properties
+++ b/WNPRC_Compliance/module.properties
@@ -3,7 +3,6 @@ Label: Personnel, Training, and Compliance Tracking
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ModuleClass: org.labkey.wnprc_compliance.WNPRC_ComplianceModule
-ModuleDependencies: LDK, DBUtils, WebUtils
 Name: WNPRC_Compliance
 SchemaVersion: 20.000
 SupportedDatabases: pgsql

--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -14,6 +14,15 @@ dependencies {
     jspImplementation project(path: "${project.parent.path}:DBUtils",  configuration: "apiJarFile")
     jspImplementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
     jspImplementation "joda-time:joda-time:2.8.1"
+
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:Viral_Load_Assay", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:DBUtils", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:WebUtils", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:GoogleDrive", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:WNPRC_Compliance", depProjectConfig: 'published', depExtension: 'module')
+
 }
 configurations.all {
     Configuration config ->

--- a/WNPRC_EHR/module.properties
+++ b/WNPRC_EHR/module.properties
@@ -1,4 +1,3 @@
 ModuleClass: org.labkey.wnprc_ehr.WNPRC_EHRModule
-ModuleDependencies: EHR, LDK, WNPRC_Compliance, DBUtils, WebUtils, GoogleDrive, Viral_Load_Assay
 SupportedDatabases: pgsql
 Name: WNPRC_EHR

--- a/WNPRC_r24/build.gradle
+++ b/WNPRC_r24/build.gradle
@@ -6,5 +6,5 @@ compileJava {
 }
 
 dependencies {
-    compile project(":server:modules:wnprc-modules:WNPRC_EHR")
+    implementation project(":server:modules:wnprc-modules:WNPRC_EHR")
 }

--- a/primateid/build.gradle
+++ b/primateid/build.gradle
@@ -4,5 +4,9 @@ dependencies {
     implementation project(":server:modules:ehrModules:ehr")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
-
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"), depProjectConfig: 'published', depExtension: 'module')
 }

--- a/primateid/module.properties
+++ b/primateid/module.properties
@@ -3,7 +3,6 @@ Name: PrimateId
 Label: PrimateId
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
-ModuleDependencies: Study, Experiment, Query, LDK, EHR
 SchemaVersion: 1.00
 ManageVersion: false
 SupportedDatabases: pgsql

--- a/wnprc_billing/build.gradle
+++ b/wnprc_billing/build.gradle
@@ -9,6 +9,12 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr_billing", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr_billing", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:wnprc-modules:WNPRC_EHR", depProjectConfig: "published", depExtension: "module")
+
 }
 
 sourceSets {

--- a/wnprc_billing/module.properties
+++ b/wnprc_billing/module.properties
@@ -1,3 +1,2 @@
 ModuleClass: org.labkey.wnprc_billing.WNPRC_BillingModule
-ModuleDependencies: WNPRC_EHR, EHR, EHR_Billing, LDK
 SupportedDatabases: pgsql


### PR DESCRIPTION
#### Rationale
If a module takes a dependency on another module's jar file, we want to also declare a dependency on the module file so when not building everything from source we'll bring in the requisite modules and their jar files to the distribution.  Only in the rare case where we depend on an API jar and also check for the existence of corresponding module will we not also include the module dependency, and in that case we would declare the dependency on the jar file using the `labkey` configuration so the jar file will get copied to the `lib` directory of the module declaring the dependency and thus be available without the module.

We have also deprecated the declaration of module dependencies in the `module.properties` file in favor of declaration in the `build.gradle` file.

#### Changes
* Add missing module dependencies
* Move module dependency declarations from `module.properties` files to `build.gradle` files
* Change dependency declarations using deprecated `compile` configuration to `implementation`.
