### PR TITLE
Generate webpack files into gen directory for better bulid caching

### DIFF
--- a/AnimalRequests/.gitignore
+++ b/AnimalRequests/.gitignore
@@ -1,3 +1,4 @@
+.gradle
 node_modules
 app.css
 app.css.map

--- a/AnimalRequests/package.json
+++ b/AnimalRequests/package.json
@@ -83,7 +83,7 @@
       }
     },
     "clean": {
-      "command": "rimraf resources/web/animalrequest/app/ ; rimraf node_modules"
+      "command": "rimraf resources/web/animalrequests/app/ && rimraf resources/web/animalrequests/gen ; rimraf node_modules"
     },
     "build-jest-test": {
       "command": "jest",

--- a/AnimalRequests/resources/views/app.view.xml
+++ b/AnimalRequests/resources/views/app.view.xml
@@ -3,7 +3,7 @@
         <permission name="login"/>
     </permissions>
     <dependencies>
-        <dependency path="animalrequests/app/app.js"/>
-        <dependency path="animalrequests/app/app.css"/>
+        <dependency path="animalrequests/gen/app/app.js"/>
+        <dependency path="animalrequests/gen/app/app.css"/>
     </dependencies>
 </view>

--- a/AnimalRequests/webpack/prod.config.js
+++ b/AnimalRequests/webpack/prod.config.js
@@ -47,7 +47,7 @@ module.exports = {
     },
 
     output: {
-        path: path.resolve(__dirname, '../resources/web/animalrequests/app/'),
+        path: path.resolve(__dirname, '../resources/web/animalrequests/gen/app/'),
         //path: path.resolve(__dirname, '../../WNPRC_EHR/resources/web/wnprc_ehr/reactjs/animalrequests/'),
         publicPath: './', // allows context path to resolve in both js/css
         filename: "[name].js"


### PR DESCRIPTION
#### Rationale
For optimal use of the Gradle build cache, we need to generate webpack output into a dedicated directory.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/98

#### Changes
* Update webpack build into `gen` directory
* Adjust npm `clean` task to clean out `gen` directory