### PR TITLE
Make WNPRC_Purchasing Postgres only

### DIFF
--- a/WNPRC_Purchasing/module.properties
+++ b/WNPRC_Purchasing/module.properties
@@ -1,3 +1,4 @@
 ModuleClass: org.labkey.wnprc_purchasing.WNPRC_PurchasingModule
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: pgsql


### PR DESCRIPTION
#### Rationale
Other WNPRC modules, as well as `EHR_Purchasing` are Postgres only.

