### PR TITLE
Issue 42062: Convert *Action<Void> to *Action<Object>

### DIFF
--- a/ApiKey/src/org/labkey/apikey/ApiKeyController.java
+++ b/ApiKey/src/org/labkey/apikey/ApiKeyController.java
@@ -21,7 +21,8 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 
-public class ApiKeyController extends SpringActionController {
+public class ApiKeyController extends SpringActionController
+{
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(ApiKeyController.class);
     public static final String NAME = "apikey";
 
@@ -31,9 +32,11 @@ public class ApiKeyController extends SpringActionController {
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction {
+    public class BeginAction extends SimpleViewAction
+    {
         @Override
-        public ModelAndView getView(Object o, BindException errors) throws Exception {
+        public ModelAndView getView(Object o, BindException errors) throws Exception
+        {
             return new JspView("/org/labkey/apikey/view/hello.jsp");
         }
 
@@ -44,10 +47,11 @@ public class ApiKeyController extends SpringActionController {
     }
 
     @RequiresNoPermission
-    public class ExecuteServiceAction extends ReadOnlyApiAction<Void>
+    public class ExecuteServiceAction extends ReadOnlyApiAction<Object>
     {
         @Override
-        public Object execute(Void v, BindException errors) throws Exception {
+        public Object execute(Object v, BindException errors) throws Exception
+        {
             HttpServletRequest req = getViewContext().getRequest();
 
             String moduleName   = req.getHeader("ModuleName");
@@ -74,9 +78,11 @@ public class ApiKeyController extends SpringActionController {
     }
 
     @RequiresNoPermission
-    public class GetKeyInfoAction extends ReadOnlyApiAction<Void> {
+    public class GetKeyInfoAction extends ReadOnlyApiAction<Object>
+    {
         @Override
-        public Object execute(Void v, BindException errors) throws Exception {
+        public Object execute(Object v, BindException errors) throws Exception
+        {
             HttpServletRequest req = getViewContext().getRequest();
 
             String apiKeyString = req.getHeader("API-Key");

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
@@ -623,10 +623,10 @@ public class WNPRC_EHRController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     @ActionNames("getChanges")
     @CSRF(CSRF.Method.POST)
-    public class GetChangeLists extends ReadOnlyApiAction<Void>
+    public class GetChangeLists extends ReadOnlyApiAction<Object>
     {
         @Override
-        public ApiResponse execute(Void form, BindException errors) throws Exception
+        public ApiResponse execute(Object form, BindException errors) throws Exception
         {
             Map<String, Object> props = new HashMap<>();
 
@@ -668,10 +668,10 @@ public class WNPRC_EHRController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     @RequiresLogin
     @ActionNames("getColonyPopulationPerMonth")
-    public class GetPopulationPerMonth extends ReadOnlyApiAction<Void>
+    public class GetPopulationPerMonth extends ReadOnlyApiAction<Object>
     {
         @Override
-        public ApiResponse execute(Void form, BindException errors)
+        public ApiResponse execute(Object form, BindException errors)
         {
             ColonyCensus colonyCensus = new ColonyCensus(getContainer(), getUser());
             Map<String, Map<LocalDate, PopulationInstant>> populations = colonyCensus.getPopulationsPerMonthForAllSpecies();
@@ -1143,10 +1143,10 @@ public class WNPRC_EHRController extends SpringActionController
 
     @RequiresSiteAdmin
     @ActionNames("UploadBCReports")
-    public class uploadBCReportAction extends MutatingApiAction<Void>
+    public class uploadBCReportAction extends MutatingApiAction<Object>
     {
         @Override
-        public Object execute(Void form, BindException errors) throws NotFoundException
+        public Object execute(Object form, BindException errors) throws NotFoundException
         {
             BCReportManager manager = new BCReportManager(getUser(), getContainer());
             manager.uploadReports();
@@ -1176,10 +1176,10 @@ public class WNPRC_EHRController extends SpringActionController
 
     @RequiresSiteAdmin
     @ActionNames("ScheduleBCReports")
-    public class ScheduleBCReportsAction extends MutatingApiAction<Void>
+    public class ScheduleBCReportsAction extends MutatingApiAction<Object>
     {
         @Override
-        public Object execute(Void form, BindException errors)
+        public Object execute(Object form, BindException errors)
         {
             BCReportRunner.schedule();
             return new JSONObject();
@@ -1188,10 +1188,10 @@ public class WNPRC_EHRController extends SpringActionController
 
     @RequiresSiteAdmin
     @ActionNames("UnscheduleBCReports")
-    public class UnscheduleBCReportsAction extends MutatingApiAction<Void>
+    public class UnscheduleBCReportsAction extends MutatingApiAction<Object>
     {
         @Override
-        public Object execute(Void form, BindException errors)
+        public Object execute(Object form, BindException errors)
         {
             BCReportRunner.unschedule();
             return new JSONObject();
@@ -1205,7 +1205,7 @@ public class WNPRC_EHRController extends SpringActionController
     @SuppressWarnings("unused")
     @RequiresLogin
     @ActionNames("manageWnprcTask")
-    public class ManageWnprcTaskAction extends SimpleRedirectAction<java.lang.Void>
+    public class ManageWnprcTaskAction extends SimpleRedirectAction<Object>
     {
         // these constants are here to hopefully prevent us from mistyping the capitalization
         // later in the method. also, they should be different enough to avoid one-off typos
@@ -1214,7 +1214,7 @@ public class WNPRC_EHRController extends SpringActionController
         private static final String LOWERCASE_FORMTYPE = "formtype";
 
         @Override
-        public @Nullable URLHelper getRedirectURL(Void aVoid)
+        public @Nullable URLHelper getRedirectURL(Object aVoid)
         {
             ActionURL oldUrl = getViewContext().getActionURL();
             ActionURL newUrl;
@@ -1280,10 +1280,10 @@ public class WNPRC_EHRController extends SpringActionController
      */
     @SuppressWarnings("unused")
     @RequiresPermission(AdminPermission.class)
-    public static class ImportDatasetDataAction extends MutatingApiAction<java.lang.Void>
+    public static class ImportDatasetDataAction extends MutatingApiAction<Object>
     {
         @Override
-        public Object execute(java.lang.Void aVoid, BindException errors)
+        public Object execute(Object aVoid, BindException errors)
         {
             // TODO: create, parse, and load some test data
             return new ApiSimpleResponse("success", true);
@@ -1292,10 +1292,10 @@ public class WNPRC_EHRController extends SpringActionController
 
     @SuppressWarnings("unused")
     @RequiresPermission(AdminPermission.class)
-    public static class ImportDatasetMetadataAction extends MutatingApiAction<java.lang.Void>
+    public static class ImportDatasetMetadataAction extends MutatingApiAction<Object>
     {
         @Override
-        public Object execute(java.lang.Void aVoid, BindException errors) throws Exception
+        public Object execute(Object aVoid, BindException errors) throws Exception
         {
             Module module = ModuleLoader.getInstance().getModule(WNPRC_EHRModule.class);
             assert module != null;

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRTestController.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRTestController.java
@@ -35,10 +35,10 @@ public class WNPRC_EHRTestController extends SpringActionController
      * definition.
      */
     @RequiresSiteAdmin
-    public static class ImportDatasetMetadataAction extends MutatingApiAction<Void>
+    public static class ImportDatasetMetadataAction extends MutatingApiAction<Object>
     {
         @Override
-        public Object execute(Void aVoid, BindException errors) throws Exception
+        public Object execute(Object form, BindException errors) throws Exception
         {
             Module module = ModuleLoader.getInstance().getModule(WNPRC_EHRModule.class);
             assert module != null;
@@ -98,10 +98,10 @@ public class WNPRC_EHRTestController extends SpringActionController
      * demographic datasets.
      */
     @RequiresSiteAdmin
-    public class CreatePregnanciesAction extends MutatingApiAction<Void>
+    public class CreatePregnanciesAction extends MutatingApiAction<Object>
     {
         @Override
-        public Object execute(Void aVoid, BindException errors)
+        public Object execute(Object form, BindException errors)
         {
             try
             {

--- a/WebUtils/src/org/labkey/webutils/WebUtilsController.java
+++ b/WebUtils/src/org/labkey/webutils/WebUtilsController.java
@@ -63,10 +63,11 @@ public class WebUtilsController extends SpringActionController
 
     @RequiresNoPermission
     @ActionNames("loginStatus")
-    public class getLoginStatus extends ReadOnlyApiAction<Void>
+    public class getLoginStatus extends ReadOnlyApiAction<Object>
     {
         @Override
-        public Object execute(Void v, BindException errors) throws Exception {
+        public Object execute(Object v, BindException errors) throws Exception
+        {
             Map<String, Object> json = new HashMap<>();
 
             // Check to see if we're logged in as a guest.
@@ -77,14 +78,16 @@ public class WebUtilsController extends SpringActionController
         }
     }
 
-    public abstract class WebUtilsJspPageAction extends SimpleJspPageAction {
+    public abstract class WebUtilsJspPageAction extends SimpleJspPageAction
+    {
         @Override
         public Module getModule() {
             return ModuleLoader.getInstance().getModule(WebUtilsModule.class);
         }
     }
 
-    public class TestPageAction extends WebUtilsJspPageAction {
+    public class TestPageAction extends WebUtilsJspPageAction
+    {
         @Override
         public String getPathToJsp() {
             return "view/TestPage.jsp";


### PR DESCRIPTION
#### Rationale
[Issue 42062: Convert *Action\<Void> to *Action\<Object> to work around JDK-16 restriction](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42062)

JDK-16_28 EA no longer allows us to declare actions with `<Void>` command types, so convert these to `<Object>`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1784