### PR TITLE
Specimen module

### DIFF
--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:GoogleDrive", depProjectConfig: 'published', depExtension: 'module')
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: "${project.parent.path}:WNPRC_Compliance", depProjectConfig: 'published', depExtension: 'module')
 
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: "published", depExtension: "module")
 }
 configurations.all {
     Configuration config ->


### PR DESCRIPTION
#### Rationale
WNPRC_EHR relies on private classes in Study (study-main), some of which rely on classes that are moving to study-api in the related PR. For now, give WNPRC_EHR a dependency on study-api. See [Ticket 42149](https://www.labkey.org/WNPRC/support%20tickets/issues-details.view?issueId=42149) as well.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1862
