### PR TITLE
Epic 8222 : WNPRC Purchasing - Receiver's page & data entry page update

### DIFF
--- a/WNPRC_EHR/resources/views/wnprcUnits.html
+++ b/WNPRC_EHR/resources/views/wnprcUnits.html
@@ -97,9 +97,9 @@ function createNavMenu()
             ]},
             {header: 'Purchasing Services',
             items: [
-                {name: 'Issue Tracker', url: '<%=contextPath%>/project/WNPRC/WNPRC_Units/Operation_Services/Purchasing/Issue_Tracker/start.view?'},
                 {name: 'Purchasing Requests', url: '<%=contextPath%>/WNPRC/WNPRC_Units/Operation_Services/Purchasing/WNPRC_Purchasing-requester.view?'},
-                {name: 'Purchasing Admin', url: '<%=contextPath%>/WNPRC/WNPRC_Units/Operation_Services/Purchasing/WNPRC_Purchasing-purchaseAdmin.view?'}
+                {name: 'Purchasing Admin', url: '<%=contextPath%>/WNPRC/WNPRC_Units/Operation_Services/Purchasing/WNPRC_Purchasing-purchaseAdmin.view?'},
+                {name: 'Purchasing Receiver', url: '<%=contextPath%>/WNPRC/WNPRC_Units/Operation_Services/Purchasing/WNPRC_Purchasing-purchaseReceiver.view?'}
             ]}
         ]
     });

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems.query.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems.query.xml
@@ -25,10 +25,15 @@
                             <fkTable>itemUnits</fkTable>
                         </fk>
                     </column>
-                    <column columnName="controlledSubstance"/>
+                    <column columnName="controlledSubstance">
+                        <formatString>Yes;No;</formatString>
+                    </column>
                     <column columnName="quantity">
                         <required>true</required>
-                        <formatString>###,##0.00</formatString>
+                        <formatString>###,##0</formatString>
+                    </column>
+                    <column columnName="quantityReceived">
+                        <formatString>###,##0</formatString>
                     </column>
                     <column columnName="unitCost">
                         <required>true</required>

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems/.qview.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems/.qview.xml
@@ -1,11 +1,27 @@
 <customView xmlns="http://labkey.org/data/xml/queryCustomView">
     <columns>
         <column name="requestRowId"/>
+        <column name="requestRowId/qcState/Label">
+            <properties>
+                <property name="columnTitle" value="Request Status"/>
+            </properties>
+        </column>
         <column name="item"/>
         <column name="itemUnitId"/>
         <column name="controlledSubstance"/>
         <column name="quantity"/>
+        <column name="quantityReceived"/>
         <column name="unitCost"/>
+        <column name="requestRowId/createdBy">
+            <properties>
+                <property name="columnTitle" value="Requester"/>
+            </properties>
+        </column>
+        <column name="requestRowId/assignedTo">
+            <properties>
+                <property name="columnTitle" value="Assigned To"/>
+            </properties>
+        </column>
     </columns>
     <sorts>
         <sort column="requestRowId" descending="true" />

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems/.qview.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems/.qview.xml
@@ -23,7 +23,4 @@
             </properties>
         </column>
     </columns>
-    <sorts>
-        <sort column="requestRowId" descending="true" />
-    </sorts>
 </customView>

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/myOpenRequests.sql
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/myOpenRequests.sql
@@ -7,6 +7,7 @@ SELECT
     pr.account || pr.otherAcctAndInves AS account,
     pr.qcState   AS requestStatus,
     pr.createdBy AS requester,
-    pr.assignedTo
+    pr.assignedTo,
+    pr.attachments
 FROM ehr_purchasing.purchasingRequests pr
 WHERE ISMEMBEROF(pr.assignedTo)

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingReceiverOverview.query.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingReceiverOverview.query.xml
@@ -1,0 +1,15 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="purchasingRequestsOverview" tableDbType="NOT_IN_DB">
+                <javaCustomizer class="org.labkey.wnprc_purchasing.table.WNPRC_PurchasingCustomizer"/>
+                <tableTitle>Line Items from Open Orders</tableTitle>
+                <columns>
+                    <column columnName="controlledSubstance">
+                        <formatString>Yes;No;</formatString>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingReceiverOverview.sql
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingReceiverOverview.sql
@@ -1,0 +1,12 @@
+SELECT
+requestRowId,
+requestRowId.vendorId.vendorName,
+item,
+requestRowId.orderDate,
+requestRowId.confirmationNum,
+requestRowId.invoiceNum,
+quantity,
+quantityReceived,
+itemUnitId.itemUnit,
+controlledSubstance
+FROM ehr_purchasing.lineItems

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingReceiverOverview.sql
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingReceiverOverview.sql
@@ -10,3 +10,4 @@ quantityReceived,
 itemUnitId.itemUnit,
 controlledSubstance
 FROM ehr_purchasing.lineItems
+WHERE requestRowId.qcState.Label = 'Order Placed'

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForAdmins.sql
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForAdmins.sql
@@ -7,5 +7,6 @@ SELECT
        pr.created   AS requestDate,
        pr.createdBy AS requester,
        pr.totalCost,
-       pr.assignedTo
+       pr.assignedTo,
+       pr.attachments
 FROM ehr_purchasing.purchasingRequests pr

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForAdmins/AllOpenRequests.qview.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForAdmins/AllOpenRequests.qview.xml
@@ -9,6 +9,7 @@
         <column name="otherAccountAndInves"/>
         <column name="requester"/>
         <column name="assignedTo"/>
+        <column name="attachments"/>
     </columns>
     <filters>
         <filter column="requestStatus/Label" operator="in" value="Review Pending; Request Approved" />

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForAdmins/CompletedRequests.qview.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForAdmins/CompletedRequests.qview.xml
@@ -8,6 +8,7 @@
         <column name="requestStatus"/>
         <column name="otherAccountAndInves"/>
         <column name="requester"/>
+        <column name="attachments"/>
     </columns>
     <filters>
         <filter column="requestStatus/Label" operator="eq" value="Order Complete" />

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/userAccountAssociations.query.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/userAccountAssociations.query.xml
@@ -5,11 +5,16 @@
                 <tableTitle>User Account Associations</tableTitle>
                 <columns>
                     <column columnName="userId">
-                        <columnTitle>User</columnTitle>
+                        <columnTitle>User or Group</columnTitle>
                         <fk>
                             <fkDbSchema>core</fkDbSchema>
-                            <fkTable>Users</fkTable>
+                            <fkTable>UsersAndGroups</fkTable>
                             <fkColumnName>UserId</fkColumnName>
+                            <filters>
+                                <filterGroup>
+                                    <filter column="DisplayName" operator="neq" value="Users"/>
+                                </filterGroup>
+                            </filters>
                         </fk>
                     </column>
                     <column columnName="account">

--- a/WNPRC_Purchasing/resources/views/purchasingAdmin.html
+++ b/WNPRC_Purchasing/resources/views/purchasingAdmin.html
@@ -53,6 +53,7 @@
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToCompletedRequestsView()">Completed Requests</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToRequestsView()">All Requests</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToPCardView()">P-Card View</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%>/project/WNPRC/WNPRC_Units/Operation_Services/Purchasing/Issue_Tracker/start.view?">Issue Tracker</a></span></div>
 
 <h4 style="font-family: Roboto;font-size: 14px;font-weight: bold; padding-top:10px;">Reference Tables</h4>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToVendorsView()">Vendors</a></span></div>

--- a/WNPRC_Purchasing/resources/views/purchasingLanding.html
+++ b/WNPRC_Purchasing/resources/views/purchasingLanding.html
@@ -8,9 +8,14 @@
         window.location = LABKEY.ActionURL.buildURL('WNPRC_Purchasing', 'purchaseAdmin', LABKEY.ActionURL.getContainer());
     }
 
+    function goToPurchaseReceiverPage() {
+        window.location = LABKEY.ActionURL.buildURL('WNPRC_Purchasing', 'purchaseReceiver', LABKEY.ActionURL.getContainer());
+    }
+
 </script>
 
 <div id="<%=h('wnprc_purchasing-admin-page')%>"></div>
 <h4 style="font-family: Roboto;font-size: 14px;font-weight: bold;">WNPRC Purchasing Portal</h4>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToRequestersPage()">Purchasing Requests</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToPurchaseAdminPage()">Purchasing Admin</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToPurchaseReceiverPage()">Purchasing Receiver</a></span></div>

--- a/WNPRC_Purchasing/resources/views/purchasingReceiver.html
+++ b/WNPRC_Purchasing/resources/views/purchasingReceiver.html
@@ -1,0 +1,10 @@
+<div id="<%=h('wnprc_purchasing-receiver')%>"></div>
+<script type="text/javascript">
+    var webpart = <%=webpartContext%>;
+    var qwp = new LABKEY.QueryWebPart({
+        renderTo: webpart.wrapperDivId,
+        schemaName: 'ehr_purchasing',
+        queryName: 'purchasingReceiverOverview'
+    });
+    qwp.render();
+</script>

--- a/WNPRC_Purchasing/resources/views/purchasingReceiver.view.xml
+++ b/WNPRC_Purchasing/resources/views/purchasingReceiver.view.xml
@@ -1,0 +1,2 @@
+<view xmlns="http://labkey.org/data/xml/view" title="">
+</view>

--- a/WNPRC_Purchasing/resources/views/purchasingReceiver.webpart.xml
+++ b/WNPRC_Purchasing/resources/views/purchasingReceiver.webpart.xml
@@ -1,0 +1,6 @@
+<webpart xmlns="http://labkey.org/data/xml/webpart" title="WNPRC Purchasing Receiver">
+    <view name="purchasingReceiver"/>
+    <locations>
+        <location name="body"/>
+    </locations>
+</webpart>

--- a/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.scss
+++ b/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.scss
@@ -53,6 +53,10 @@
   margin-left: -6%;
 }
 
+.quantity-received-input {
+  margin-right: -5%;
+}
+
 .subtotal-input {
   margin-left: -4%;
   text-align:right;

--- a/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
+++ b/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
@@ -322,6 +322,9 @@ export const App: FC = memo(() => {
                                         case 'quantity':
                                             lineItemErrors.push({ fieldName: 'quantity', errorMessage: errMsg });
                                             break;
+                                        case 'quantityReceived':
+                                            lineItemErrors.push({ fieldName: 'quantityReceived', errorMessage: errMsg });
+                                            break;
                                         case 'rowIndex':
                                             const txt = errMsg; // this is just the row index set on server side to identify error on specific line item index
                                             errorOnIndex = parseInt(txt, 10);
@@ -356,7 +359,38 @@ export const App: FC = memo(() => {
                         }
 
                         if (hasLineItemError) {
-                            setLineItemErrorMsg(lineItemsErrorCount > 1 ? msg + 's.' : msg + '.');
+                            let lineItemErrMsg = "Unable to submit request, ";
+                            let negQuantityErrMsg = "";
+
+                            lineItems?.forEach((lineItem) => {
+                                if (lineItem.quantity < 0 || lineItem.quantityReceived < 0)
+                                    negQuantityErrMsg += "invalid quantity"
+                            });
+
+                            let missingReqFieldCount = 0;
+                            let missingReqFieldMsg = "missing required field";
+
+                            if (lineItems?.length > 0) {
+                                if (!lineItems[errorOnIndex].item)
+                                    ++missingReqFieldCount;
+                                if (!lineItems[errorOnIndex].itemUnit)
+                                    ++missingReqFieldCount;
+                                if (!lineItems[errorOnIndex].quantity)
+                                    ++missingReqFieldCount;
+                                if (!lineItems[errorOnIndex].unitCost)
+                                    ++missingReqFieldCount;
+                            }
+
+                            if (missingReqFieldCount > 0) {
+                                lineItemErrMsg = missingReqFieldCount > 1 ? (lineItemErrMsg + missingReqFieldMsg + 's') : (lineItemErrMsg + missingReqFieldMsg)
+                            }
+                            if (missingReqFieldCount > 0 && negQuantityErrMsg.length > 0) {
+                                lineItemErrMsg += " & ";
+                            }
+                            if (negQuantityErrMsg.length > 0) {
+                                lineItemErrMsg += negQuantityErrMsg;
+                            }
+                            setLineItemErrorMsg(lineItemErrMsg + ".");
                         }
                     } else if (reject?.exception) {
                         setGlobalErrorMsg(reject.exception);

--- a/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
@@ -73,15 +73,15 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                             />
                         </Col>
                         <Col xs={1}>
-                            <QuantityReceivedInput
-                                value={model.quantityReceived}
-                                onChange={onValueChange}
-                            />
-                        </Col>
-                        <Col xs={2}>
                             <ControlledSubstance
                                 value={model.controlledSubstance}
                                 isReadOnly={true}
+                            />
+                        </Col>
+                        <Col xs={1}>
+                            <QuantityReceivedInput
+                                value={model.quantityReceived}
+                                onChange={onValueChange}
                             />
                         </Col>
                     </Row>

--- a/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
@@ -13,6 +13,7 @@ import {
     UnitInput,
     UnitCostInput,
     UnitQuantityInput,
+    QuantityReceivedInput,
 } from './LineItemsPanelInputs';
 
 interface LineItemProps {
@@ -20,10 +21,12 @@ interface LineItemProps {
     onInputChange: (model: LineItemModel, index: number) => void;
     onDelete: (rowIndex: number) => void;
     rowIndex: number;
+    isAdmin: boolean;
+    canUpdate: boolean;
 }
 
 export const LineItemRow: FC<LineItemProps> = memo(props => {
-    const { model, onInputChange, onDelete, rowIndex } = props;
+    const { model, onInputChange, onDelete, rowIndex, isAdmin, canUpdate } = props;
 
     const onValueChange = useCallback(
         (colName, value) => {
@@ -47,52 +50,100 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
 
     return (
         <>
-            <Row className="line-item-row" key={'line-item-row-' + rowIndex}>
-                <Col xs={4}>
-                    <DescriptionInput
-                        value={model.item}
-                        hasError={model.errors?.find(field => field.fieldName === 'item')}
-                        onChange={onValueChange}
-                    />
-                </Col>
-                <Col xs={1}>
-                    <UnitInput
-                        value={model.itemUnit}
-                        hasError={model.errors?.find(field => field.fieldName === 'itemUnit')}
-                        onChange={onValueChange}
-                    />
-                </Col>
-                <Col xs={1}>
-                    <UnitCostInput
-                        value={model.unitCost}
-                        hasError={model.errors?.find(field => field.fieldName === 'unitCost')}
-                        onChange={onValueChange}
-                    />
-                </Col>
-                <Col xs={1}>
-                    <UnitQuantityInput
-                        value={model.quantity}
-                        hasError={model.errors?.find(field => field.fieldName === 'quantity')}
-                        onChange={onValueChange}
-                    />
-                </Col>
-                <Col xs={1}>
-                    <SubtotalInput unitCost={model.unitCost} quantity={model.quantity} />
-                </Col>
-                <Col xs={2}>
-                    <ControlledSubstance value={model.controlledSubstance} onChange={onValueChange} />
-                </Col>
-                <Col xs={2}>
-                    <span
-                        id={'delete-line-item-row-' + rowIndex}
-                        title="Delete item"
-                        className="delete-item-icon"
-                        onClick={onDeleteRow}
-                    >
-                        <FontAwesomeIcon className="fa-faTimesCircle" icon={faTimesCircle} />
-                    </span>
-                </Col>
-            </Row>
+            {
+                !isAdmin && canUpdate &&
+                (
+                    <Row className="line-item-row" key={'line-item-row-' + rowIndex}>
+                        <Col xs={4}>
+                            <DescriptionInput
+                                value={model.item}
+                                isReadOnly={true}
+                            />
+                        </Col>
+                        <Col xs={1}>
+                            <UnitInput
+                                value={model.itemUnit}
+                                isReadOnly={true}
+                            />
+                        </Col>
+                        <Col xs={1}>
+                            <UnitQuantityInput
+                                value={model.quantity}
+                                isReadOnly={true}
+                            />
+                        </Col>
+                        <Col xs={1}>
+                            <QuantityReceivedInput
+                                value={model.quantityReceived}
+                                onChange={onValueChange}
+                            />
+                        </Col>
+                        <Col xs={2}>
+                            <ControlledSubstance
+                                value={model.controlledSubstance}
+                                isReadOnly={true}
+                            />
+                        </Col>
+                    </Row>
+                )
+            }
+            {
+                (isAdmin || !canUpdate) &&
+                (
+                    <Row className="line-item-row" key={'line-item-row-' + rowIndex}>
+                        <Col xs={4}>
+                            <DescriptionInput
+                                value={model.item}
+                                hasError={model.errors?.find(field => field.fieldName === 'item')}
+                                onChange={onValueChange}
+                            />
+                        </Col>
+                        <Col xs={1}>
+                            <UnitInput
+                                value={model.itemUnit}
+                                hasError={model.errors?.find(field => field.fieldName === 'itemUnit')}
+                                onChange={onValueChange}
+                            />
+                        </Col>
+                        <Col xs={1}>
+                            <UnitCostInput
+                                value={model.unitCost}
+                                hasError={model.errors?.find(field => field.fieldName === 'unitCost')}
+                                onChange={onValueChange}
+                            />
+                        </Col>
+                        <Col xs={1}>
+                            <UnitQuantityInput
+                                value={model.quantity}
+                                hasError={model.errors?.find(field => field.fieldName === 'quantity')}
+                                onChange={onValueChange}
+                            />
+                        </Col>
+                        <Col xs={1}>
+                            <SubtotalInput unitCost={model.unitCost} quantity={model.quantity} />
+                        </Col>
+                        <Col xs={1}>
+                            <QuantityReceivedInput
+                                value={model.quantityReceived}
+                                onChange={onValueChange}
+                            />
+                        </Col>
+                        <Col xs={2}>
+                            <ControlledSubstance value={model.controlledSubstance} onChange={onValueChange} />
+                        </Col>
+                        <Col xs={1}>
+                        <span
+                            id={'delete-line-item-row-' + rowIndex}
+                            title="Delete item"
+                            className="delete-item-icon"
+                            onClick={onDeleteRow}
+                        >
+                            <FontAwesomeIcon className="fa-faTimesCircle" icon={faTimesCircle} />
+                        </span>
+                        </Col>
+                    </Row>
+                )
+            }
         </>
     );
 });

--- a/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
@@ -23,10 +23,12 @@ interface LineItemProps {
     rowIndex: number;
     isAdmin: boolean;
     canUpdate: boolean;
+    canInsert: boolean;
+    hasRequestId?: boolean;
 }
 
 export const LineItemRow: FC<LineItemProps> = memo(props => {
-    const { model, onInputChange, onDelete, rowIndex, isAdmin, canUpdate } = props;
+    const { model, onInputChange, onDelete, rowIndex, isAdmin, canUpdate, canInsert, hasRequestId } = props;
 
     const onValueChange = useCallback(
         (colName, value) => {
@@ -51,99 +53,77 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
     return (
         <>
             {
-                !isAdmin && canUpdate &&
-                (
-                    <Row className="line-item-row" key={'line-item-row-' + rowIndex}>
-                        <Col xs={4}>
-                            <DescriptionInput
-                                value={model.item}
-                                isReadOnly={true}
-                            />
-                        </Col>
-                        <Col xs={1}>
-                            <UnitInput
-                                value={model.itemUnit}
-                                isReadOnly={true}
-                            />
-                        </Col>
-                        <Col xs={1}>
-                            <UnitQuantityInput
-                                value={model.quantity}
-                                isReadOnly={true}
-                            />
-                        </Col>
-                        <Col xs={1}>
-                            <ControlledSubstance
-                                value={model.controlledSubstance}
-                                isReadOnly={true}
-                            />
-                        </Col>
-                        <Col xs={1}>
-                            <QuantityReceivedInput
-                                value={model.quantityReceived}
-                                onChange={onValueChange}
-                            />
-                        </Col>
-                    </Row>
-                )
-            }
-            {
-                (isAdmin || !canUpdate) &&
-                (
-                    <Row className="line-item-row" key={'line-item-row-' + rowIndex}>
-                        <Col xs={4}>
-                            <DescriptionInput
-                                value={model.item}
-                                hasError={model.errors?.find(field => field.fieldName === 'item')}
-                                onChange={onValueChange}
-                            />
-                        </Col>
-                        <Col xs={1}>
-                            <UnitInput
-                                value={model.itemUnit}
-                                hasError={model.errors?.find(field => field.fieldName === 'itemUnit')}
-                                onChange={onValueChange}
-                            />
-                        </Col>
+                <Row className="line-item-row" key={'line-item-row-' + rowIndex}>
+                    <Col xs={4}>
+                        <DescriptionInput
+                            value={model.item}
+                            hasError={model.errors?.find(field => field.fieldName === 'item')}
+                            onChange={onValueChange}
+                            isReadOnly={!isAdmin && canUpdate}
+                        />
+                    </Col>
+                    <Col xs={1}>
+                        <UnitInput
+                            value={model.itemUnit}
+                            hasError={model.errors?.find(field => field.fieldName === 'itemUnit')}
+                            onChange={onValueChange}
+                            isReadOnly={!isAdmin && canUpdate}
+                        />
+                    </Col>
+                    { (isAdmin || !canUpdate) &&
                         <Col xs={1}>
                             <UnitCostInput
-                                value={model.unitCost}
-                                hasError={model.errors?.find(field => field.fieldName === 'unitCost')}
-                                onChange={onValueChange}
+                                    value={model.unitCost}
+                                    hasError={model.errors?.find(field => field.fieldName === 'unitCost')}
+                                    onChange={onValueChange}
                             />
                         </Col>
-                        <Col xs={1}>
-                            <UnitQuantityInput
-                                value={model.quantity}
-                                hasError={model.errors?.find(field => field.fieldName === 'quantity')}
-                                onChange={onValueChange}
-                            />
-                        </Col>
+                    }
+                    <Col xs={1}>
+                        <UnitQuantityInput
+                            value={model.quantity}
+                            hasError={model.errors?.find(field => field.fieldName === 'quantity')}
+                            onChange={onValueChange}
+                            isReadOnly={!isAdmin && canUpdate}
+                        />
+                    </Col>
+                    { (isAdmin || !canUpdate) &&
                         <Col xs={1}>
                             <SubtotalInput unitCost={model.unitCost} quantity={model.quantity} />
                         </Col>
+                    }
+                    <Col xs={!hasRequestId ? 2 : 1}>
+                        <ControlledSubstance
+                            value={model.controlledSubstance}
+                            onChange={onValueChange}
+                            isReadOnly={!isAdmin && canUpdate}/>
+                    </Col>
+
+                    { hasRequestId && (isAdmin || canUpdate) &&
                         <Col xs={1}>
                             <QuantityReceivedInput
                                 value={model.quantityReceived}
                                 onChange={onValueChange}
                             />
                         </Col>
-                        <Col xs={2}>
-                            <ControlledSubstance value={model.controlledSubstance} onChange={onValueChange} />
-                        </Col>
+                    }
+
+                    <Col xs={2}/>
+                    <Col xs={1}/>
+                    {(isAdmin || !canUpdate) &&
                         <Col xs={1}>
-                        <span
-                            id={'delete-line-item-row-' + rowIndex}
-                            title="Delete item"
-                            className="delete-item-icon"
-                            onClick={onDeleteRow}
-                        >
-                            <FontAwesomeIcon className="fa-faTimesCircle" icon={faTimesCircle} />
-                        </span>
+                                <span
+                                        id={'delete-line-item-row-' + rowIndex}
+                                        title="Delete item"
+                                        className="delete-item-icon"
+                                        onClick={onDeleteRow}
+                                >
+                                    <FontAwesomeIcon className="fa-faTimesCircle" icon={faTimesCircle}/>
+                                </span>
                         </Col>
-                    </Row>
-                )
+                    }
+                </Row>
             }
         </>
-    );
+    )
 });

--- a/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
@@ -63,6 +63,12 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                         />
                     </Col>
                     <Col xs={1}>
+                        <ControlledSubstance
+                            value={model.controlledSubstance}
+                            onChange={onValueChange}
+                            isReadOnly={!isAdmin && canUpdate}/>
+                    </Col>
+                    <Col xs={1}>
                         <UnitInput
                             value={model.itemUnit}
                             hasError={model.errors?.find(field => field.fieldName === 'itemUnit')}
@@ -87,29 +93,25 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                             isReadOnly={!isAdmin && canUpdate}
                         />
                     </Col>
+                    { hasRequestId && (isAdmin || canUpdate) &&
+                    <Col xs={1}>
+                        <QuantityReceivedInput
+                                value={model.quantityReceived}
+                                onChange={onValueChange}
+                        />
+                    </Col>
+                    }
                     { (isAdmin || !canUpdate) &&
                         <Col xs={1}>
                             <SubtotalInput unitCost={model.unitCost} quantity={model.quantity} />
                         </Col>
                     }
-                    <Col xs={!hasRequestId ? 2 : 1}>
-                        <ControlledSubstance
-                            value={model.controlledSubstance}
-                            onChange={onValueChange}
-                            isReadOnly={!isAdmin && canUpdate}/>
-                    </Col>
-
-                    { hasRequestId && (isAdmin || canUpdate) &&
-                        <Col xs={1}>
-                            <QuantityReceivedInput
-                                value={model.quantityReceived}
-                                onChange={onValueChange}
-                            />
-                        </Col>
-                    }
 
                     <Col xs={2}/>
                     <Col xs={1}/>
+                    { !hasRequestId &&
+                        <Col xs={2}/>
+                    }
                     {(isAdmin || !canUpdate) &&
                         <Col xs={1}>
                                 <span

--- a/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
@@ -33,7 +33,7 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
     const onValueChange = useCallback(
         (colName, value) => {
             const updatedModel = produce(model, (draft: Draft<LineItemModel>) => {
-                draft[colName] = value;
+                draft[colName] = value === "" ? null : value;
                 if (model.errors?.length > 0) {
                     draft['errors'] = model.errors.filter(field => field.fieldName !== colName);
                 }
@@ -97,6 +97,7 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                     <Col xs={1}>
                         <QuantityReceivedInput
                                 value={model.quantityReceived}
+                                hasError={model.errors?.find(field => field.fieldName === 'quantityReceived')}
                                 onChange={onValueChange}
                         />
                     </Col>

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
@@ -17,10 +17,11 @@ interface Props {
     hasRequestId?: boolean;
     isAdmin: boolean;
     canUpdate: boolean;
+    canInsert: boolean;
 }
 
 export const LineItemsPanel: FC<Props> = memo(props => {
-    const { lineItems, onChange, errorMsg, hasRequestId, isAdmin, canUpdate } = props;
+    const { lineItems, onChange, errorMsg, hasRequestId, isAdmin, canUpdate, canInsert } = props;
 
     const lineItemRowChange = useCallback(
         (lineItem, updatedRowIndex) => {
@@ -69,26 +70,21 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                     </div>
                     <div>
                         {
-                            !isAdmin && canUpdate && (
                             <Row className="line-item-row-header">
                                 <Col xs={4}>Part no./Item description *</Col>
                                 <Col xs={1}>Unit *</Col>
+                                { (isAdmin || !canUpdate) &&
+                                    <Col xs={1}>Unit Cost ($) *</Col>
+                                }
                                 <Col xs={1}>Quantity *</Col>
-                                <Col xs={1}>Controlled substance</Col>
-                                <Col xs={1}>Quantity received</Col>
-                            </Row>)
-                        }
-                        {
-                            (isAdmin || !canUpdate) && (
-                            <Row className="line-item-row-header">
-                                <Col xs={4}>Part no./Item description *</Col>
-                                <Col xs={1}>Unit *</Col>
-                                <Col xs={1}>Unit Cost ($) *</Col>
-                                <Col xs={1}>Quantity *</Col>
-                                <Col xs={1}>Subtotal ($)</Col>
-                                <Col xs={1}>Quantity received</Col>
-                                <Col xs={2}>Controlled substance</Col>
-                            </Row>)
+                                { (isAdmin || !canUpdate) &&
+                                    <Col xs={1}>Subtotal ($)</Col>
+                                }
+                                <Col xs={!hasRequestId ? 2 : 1}>Controlled substance</Col>
+                                { hasRequestId && (isAdmin || canUpdate) &&
+                                    <Col xs={1}>Quantity received</Col>
+                                }
+                            </Row>
                         }
                     </div>
                     <div>
@@ -102,6 +98,8 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                                     onDelete={onDeleteRow}
                                     isAdmin={isAdmin}
                                     canUpdate={canUpdate}
+                                    canInsert={canInsert}
+                                    hasRequestId={hasRequestId}
                                 />
                             );
                         })}

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback } from 'react';
+import React, {FC, memo, useCallback, useMemo} from 'react';
 import { Panel, Col, Row } from 'react-bootstrap';
 import produce, { Draft } from 'immer';
 
@@ -45,104 +45,101 @@ export const LineItemsPanel: FC<Props> = memo(props => {
         [lineItems, onChange]
     );
 
-    const onClickAddRow = () => {
+    const onClickAddRow = useCallback(()=> {
         const updatedLineItems = produce(lineItems, (draft: Draft<LineItemModel[]>) => {
             draft.push(LineItemModel.create());
         });
         onChange(updatedLineItems);
-    };
+    }, [lineItems]);
+
+    const getTotal = useMemo(() => {
+        return formatCurrency(
+            lineItems.reduce(function (accumulatedVal, lineItem) {
+                return lineItem.unitCost && lineItem.quantity
+                    ? accumulatedVal + lineItem.unitCost * lineItem.quantity
+                    : accumulatedVal;
+            }, 0)
+        )
+    }, [lineItems]);
 
     return (
         <>
-            {
-                <Panel
-                    className="panel panel-default"
-                    expanded={true}
-                    onToggle={function () {
-                    }} // this is added to suppress JS warning about providing an expanded prop without onToggle
-                >
-                    <div className="bg-primary">
-                        <Panel.Heading>
-                            <div className="panel-title">
-                                {(!hasRequestId && 'Specify Items') || (hasRequestId && 'Requested Items')}
-                            </div>
-                        </Panel.Heading>
-                    </div>
-                    <div>
-                        {
-                            <Row className="line-item-row-header">
-                                <Col xs={4}>Part no./Item description *</Col>
-                                <Col xs={1}>Controlled substance</Col>
-                                <Col xs={1}>Unit *</Col>
-                                { (isAdmin || !canUpdate) &&
-                                    <Col xs={1}>Unit Cost ($) *</Col>
-                                }
-                                <Col xs={1}>Quantity *</Col>
-                                { hasRequestId && (isAdmin || canUpdate) &&
-                                    <Col xs={1}>Quantity received</Col>
-                                }
-                                { (isAdmin || !canUpdate) &&
-                                    <Col xs={1}>Subtotal ($)</Col>
-                                }
-                            </Row>
-                        }
-                    </div>
-                    <div>
-                        {lineItems.map((lineItem, idx) => {
-                            return (
-                                <LineItemRow
-                                    rowIndex={idx}
-                                    key={'line-item-' + idx}
-                                    model={lineItem}
-                                    onInputChange={lineItemRowChange}
-                                    onDelete={onDeleteRow}
-                                    isAdmin={isAdmin}
-                                    canUpdate={canUpdate}
-                                    canInsert={canInsert}
-                                    hasRequestId={hasRequestId}
-                                />
-                            );
-                        })}
-                    </div>
-                    <div>
-                        {
-                            (isAdmin || !canUpdate) && (
-                                <>
-                                    <div>
-                                        <Row>
-                                            <Col xs={4}></Col>
+            <Panel
+                className="panel panel-default"
+                expanded={true}
+                onToggle={function () {
+                }} // this is added to suppress JS warning about providing an expanded prop without onToggle
+            >
+                <div className="bg-primary">
+                    <Panel.Heading>
+                        <div className="panel-title">
+                            {(!hasRequestId && 'Specify Items') || (hasRequestId && 'Requested Items')}
+                        </div>
+                    </Panel.Heading>
+                </div>
+                <div>
+                        <Row className="line-item-row-header">
+                            <Col xs={4}>Part no./Item description *</Col>
+                            <Col xs={1}>Controlled substance</Col>
+                            <Col xs={1}>Unit *</Col>
+                            { (isAdmin || !canUpdate) &&
+                                <Col xs={1}>Unit Cost ($) *</Col>
+                            }
+                            <Col xs={1}>Quantity *</Col>
+                            { hasRequestId && (isAdmin || canUpdate) &&
+                                <Col xs={1}>Quantity received</Col>
+                            }
+                            { (isAdmin || !canUpdate) &&
+                                <Col xs={1}>Subtotal ($)</Col>
+                            }
+                        </Row>
+                </div>
+                <div>
+                    {lineItems.map((lineItem, idx) => {
+                        return (
+                            <LineItemRow
+                                rowIndex={idx}
+                                key={'line-item-' + idx}
+                                model={lineItem}
+                                onInputChange={lineItemRowChange}
+                                onDelete={onDeleteRow}
+                                isAdmin={isAdmin}
+                                canUpdate={canUpdate}
+                                canInsert={canInsert}
+                                hasRequestId={hasRequestId}
+                            />
+                        );
+                    })}
+                </div>
+                <div>
+                    { (isAdmin || !canUpdate) && (
+                            <>
+                                <div>
+                                    <Row>
+                                        <Col xs={6}></Col>
+                                        {hasRequestId && (isAdmin || canUpdate) &&
                                             <Col xs={1}></Col>
-                                            <Col xs={1}></Col>
-                                            {hasRequestId && (isAdmin || canUpdate) &&
-                                                <Col xs={1}></Col>
-                                            }
-                                            <Col xs={1}></Col>
-                                            <Col className="calc-total" xs={1}>
-                                                Total ($):
-                                            </Col>
-                                            <Col className="calc-total-val" xs={1}>
-                                                {formatCurrency(
-                                                    lineItems.reduce(function (accumulatedVal, lineItem) {
-                                                        return lineItem.unitCost && lineItem.quantity
-                                                            ? accumulatedVal + lineItem.unitCost * lineItem.quantity
-                                                            : accumulatedVal;
-                                                    }, 0)
-                                                )}
-                                            </Col>
-                                        </Row>
-                                    </div>
-                                    <div className="add-item">
-                                        <span id="add-line-item-row" title="Add item" className="add-item-icon" onClick={onClickAddRow}>
-                                        <FontAwesomeIcon className="fa-faPlusCircle" icon={faPlusCircle} color="green" /> Add item
-                                        </span>
-                                    </div>
-                                    {errorMsg && <div className="alert alert-danger">{errorMsg}</div>}
-                                </>
-                            )
-                        }
-                    </div>
-                </Panel>
-            }
+                                        }
+                                        <Col xs={1}></Col>
+                                        <Col className="calc-total" xs={1}>
+                                            Total ($):
+                                        </Col>
+                                        <Col className="calc-total-val" xs={1}>{getTotal}
+                                        </Col>
+                                    </Row>
+                                </div>
+                                <div className="add-item">
+                                    <span id="add-line-item-row" title="Add item" className="add-item-icon"
+                                          onClick={onClickAddRow}>
+                                    <FontAwesomeIcon className="fa-faPlusCircle" icon={faPlusCircle} color="green"/> Add item
+                                    </span>
+                                </div>
+                                {errorMsg && <div className="alert alert-danger">{errorMsg}</div>}
+                            </>
+                        )
+                    }
+                </div>
+            </Panel>
         </>
     );
 });

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
@@ -72,17 +72,17 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                         {
                             <Row className="line-item-row-header">
                                 <Col xs={4}>Part no./Item description *</Col>
+                                <Col xs={1}>Controlled substance</Col>
                                 <Col xs={1}>Unit *</Col>
                                 { (isAdmin || !canUpdate) &&
                                     <Col xs={1}>Unit Cost ($) *</Col>
                                 }
                                 <Col xs={1}>Quantity *</Col>
-                                { (isAdmin || !canUpdate) &&
-                                    <Col xs={1}>Subtotal ($)</Col>
-                                }
-                                <Col xs={!hasRequestId ? 2 : 1}>Controlled substance</Col>
                                 { hasRequestId && (isAdmin || canUpdate) &&
                                     <Col xs={1}>Quantity received</Col>
+                                }
+                                { (isAdmin || !canUpdate) &&
+                                    <Col xs={1}>Subtotal ($)</Col>
                                 }
                             </Row>
                         }
@@ -113,6 +113,10 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                                             <Col xs={4}></Col>
                                             <Col xs={1}></Col>
                                             <Col xs={1}></Col>
+                                            {hasRequestId && (isAdmin || canUpdate) &&
+                                                <Col xs={1}></Col>
+                                            }
+                                            <Col xs={1}></Col>
                                             <Col className="calc-total" xs={1}>
                                                 Total ($):
                                             </Col>
@@ -125,8 +129,6 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                                                     }, 0)
                                                 )}
                                             </Col>
-                                            <Col xs={1}></Col>
-                                            <Col xs={1}></Col>
                                         </Row>
                                     </div>
                                     <div className="add-item">

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
@@ -74,8 +74,8 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                                 <Col xs={4}>Part no./Item description *</Col>
                                 <Col xs={1}>Unit *</Col>
                                 <Col xs={1}>Quantity *</Col>
+                                <Col xs={1}>Controlled substance</Col>
                                 <Col xs={1}>Quantity received</Col>
-                                <Col xs={2}>Controlled substance</Col>
                             </Row>)
                         }
                         {

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
@@ -15,10 +15,12 @@ interface Props {
     onChange: (lineItems: LineItemModel[], rowIdToDelete?: number) => void;
     errorMsg?: string;
     hasRequestId?: boolean;
+    isAdmin: boolean;
+    canUpdate: boolean;
 }
 
 export const LineItemsPanel: FC<Props> = memo(props => {
-    const { lineItems, onChange, errorMsg, hasRequestId } = props;
+    const { lineItems, onChange, errorMsg, hasRequestId, isAdmin, canUpdate } = props;
 
     const lineItemRowChange = useCallback(
         (lineItem, updatedRowIndex) => {
@@ -50,67 +52,97 @@ export const LineItemsPanel: FC<Props> = memo(props => {
     };
 
     return (
-        <Panel
-            className="panel panel-default"
-            expanded={true}
-            onToggle={function () {}} // this is added to suppress JS warning about providing an expanded prop without onToggle
-        >
-            <div className="bg-primary">
-                <Panel.Heading>
-                    <div className="panel-title">
-                        {(!hasRequestId && 'Specify Items') || (hasRequestId && 'Requested Items')}
+        <>
+            {
+                <Panel
+                    className="panel panel-default"
+                    expanded={true}
+                    onToggle={function () {
+                    }} // this is added to suppress JS warning about providing an expanded prop without onToggle
+                >
+                    <div className="bg-primary">
+                        <Panel.Heading>
+                            <div className="panel-title">
+                                {(!hasRequestId && 'Specify Items') || (hasRequestId && 'Requested Items')}
+                            </div>
+                        </Panel.Heading>
                     </div>
-                </Panel.Heading>
-            </div>
-            <div>
-                <Row className="line-item-row-header">
-                    <Col xs={4}>Part no./Item description *</Col>
-                    <Col xs={1}>Unit *</Col>
-                    <Col xs={1}>Unit Cost ($) *</Col>
-                    <Col xs={1}>Quantity *</Col>
-                    <Col xs={1}>Subtotal ($)</Col>
-                    <Col xs={2}>Controlled substance</Col>
-                </Row>
-            </div>
-            <div>
-                {lineItems.map((lineItem, idx) => {
-                    return (
-                        <LineItemRow
-                            rowIndex={idx}
-                            key={'line-item-' + idx}
-                            model={lineItem}
-                            onInputChange={lineItemRowChange}
-                            onDelete={onDeleteRow}
-                        />
-                    );
-                })}
-            </div>
-            <div>
-                <Row>
-                    <Col xs={4}></Col>
-                    <Col xs={1}></Col>
-                    <Col xs={1}></Col>
-                    <Col className="calc-total" xs={1}>
-                        Total ($):
-                    </Col>
-                    <Col className="calc-total-val" xs={1}>
-                        {formatCurrency(
-                            lineItems.reduce(function (accumulatedVal, lineItem) {
-                                return lineItem.unitCost && lineItem.quantity
-                                    ? accumulatedVal + lineItem.unitCost * lineItem.quantity
-                                    : accumulatedVal;
-                            }, 0)
-                        )}
-                    </Col>
-                    <Col xs={1}></Col>
-                </Row>
-            </div>
-            <div className="add-item">
-                <span id="add-line-item-row" title="Add item" className="add-item-icon" onClick={onClickAddRow}>
-                    <FontAwesomeIcon className="fa-faPlusCircle" icon={faPlusCircle} color="green" /> Add item
-                </span>
-            </div>
-            {errorMsg && <div className="alert alert-danger">{errorMsg}</div>}
-        </Panel>
+                    <div>
+                        {
+                            !isAdmin && canUpdate && (
+                            <Row className="line-item-row-header">
+                                <Col xs={4}>Part no./Item description *</Col>
+                                <Col xs={1}>Unit *</Col>
+                                <Col xs={1}>Quantity *</Col>
+                                <Col xs={1}>Quantity received</Col>
+                                <Col xs={2}>Controlled substance</Col>
+                            </Row>)
+                        }
+                        {
+                            (isAdmin || !canUpdate) && (
+                            <Row className="line-item-row-header">
+                                <Col xs={4}>Part no./Item description *</Col>
+                                <Col xs={1}>Unit *</Col>
+                                <Col xs={1}>Unit Cost ($) *</Col>
+                                <Col xs={1}>Quantity *</Col>
+                                <Col xs={1}>Subtotal ($)</Col>
+                                <Col xs={1}>Quantity received</Col>
+                                <Col xs={2}>Controlled substance</Col>
+                            </Row>)
+                        }
+                    </div>
+                    <div>
+                        {lineItems.map((lineItem, idx) => {
+                            return (
+                                <LineItemRow
+                                    rowIndex={idx}
+                                    key={'line-item-' + idx}
+                                    model={lineItem}
+                                    onInputChange={lineItemRowChange}
+                                    onDelete={onDeleteRow}
+                                    isAdmin={isAdmin}
+                                    canUpdate={canUpdate}
+                                />
+                            );
+                        })}
+                    </div>
+                    <div>
+                        {
+                            (isAdmin || !canUpdate) && (
+                                <>
+                                    <div>
+                                        <Row>
+                                            <Col xs={4}></Col>
+                                            <Col xs={1}></Col>
+                                            <Col xs={1}></Col>
+                                            <Col className="calc-total" xs={1}>
+                                                Total ($):
+                                            </Col>
+                                            <Col className="calc-total-val" xs={1}>
+                                                {formatCurrency(
+                                                    lineItems.reduce(function (accumulatedVal, lineItem) {
+                                                        return lineItem.unitCost && lineItem.quantity
+                                                            ? accumulatedVal + lineItem.unitCost * lineItem.quantity
+                                                            : accumulatedVal;
+                                                    }, 0)
+                                                )}
+                                            </Col>
+                                            <Col xs={1}></Col>
+                                            <Col xs={1}></Col>
+                                        </Row>
+                                    </div>
+                                    <div className="add-item">
+                                        <span id="add-line-item-row" title="Add item" className="add-item-icon" onClick={onClickAddRow}>
+                                        <FontAwesomeIcon className="fa-faPlusCircle" icon={faPlusCircle} color="green" /> Add item
+                                        </span>
+                                    </div>
+                                    {errorMsg && <div className="alert alert-danger">{errorMsg}</div>}
+                                </>
+                            )
+                        }
+                    </div>
+                </Panel>
+            }
+        </>
     );
 });

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
@@ -6,12 +6,13 @@ import { createOptions, formatCurrency } from './Utils';
 
 interface InputProps {
     value: any;
-    onChange: (colName, value) => void;
+    onChange?: (colName, value) => void;
     hasError?: boolean;
+    isReadOnly?: boolean;
 }
 
 export const DescriptionInput: FC<InputProps> = memo(props => {
-    const { onChange, value, hasError } = props;
+    const { onChange, value, hasError, isReadOnly } = props;
 
     const onTextChange = useCallback(
         evt => {
@@ -28,12 +29,13 @@ export const DescriptionInput: FC<InputProps> = memo(props => {
             value={value}
             onChange={onTextChange}
             id="item-description-id"
+            readOnly={isReadOnly}
         />
     );
 });
 
 export const UnitInput: FC<InputProps> = memo(props => {
-    const { onChange, value, hasError } = props;
+    const { onChange, value, hasError, isReadOnly } = props;
     const [dropDownVals, setDropDownVals] = useState<any[]>();
 
     useEffect(() => {
@@ -56,6 +58,7 @@ export const UnitInput: FC<InputProps> = memo(props => {
             className={'line-item-row-input unit-input form-control ' + (hasError ? 'field-validation-error' : '')}
             value={value}
             onChange={onValueChange}
+            disabled={isReadOnly}
         >
             <option hidden value="">
                 Select
@@ -67,8 +70,9 @@ export const UnitInput: FC<InputProps> = memo(props => {
 
 interface NumericInputProps {
     value: number;
-    onChange: (colName, value) => void;
+    onChange?: (colName, value) => void;
     hasError?: boolean;
+    isReadOnly?: boolean;
 }
 
 export const UnitCostInput: FC<NumericInputProps> = memo(props => {
@@ -94,7 +98,7 @@ export const UnitCostInput: FC<NumericInputProps> = memo(props => {
 });
 
 export const UnitQuantityInput: FC<NumericInputProps> = memo(props => {
-    const { onChange, value, hasError } = props;
+    const { onChange, value, hasError, isReadOnly } = props;
 
     const onValueChange = useCallback(
         evt => {
@@ -111,6 +115,30 @@ export const UnitQuantityInput: FC<NumericInputProps> = memo(props => {
             pattern="[0-9]*"
             id="unit-quantity-id"
             type="number"
+            readOnly={isReadOnly}
+        />
+    );
+});
+
+export const QuantityReceivedInput: FC<NumericInputProps> = memo(props => {
+    const { onChange, value, hasError, isReadOnly } = props;
+
+    const onValueChange = useCallback(
+        evt => {
+            onChange('quantityReceived', evt.target.value);
+        },
+        [onChange]
+    );
+
+    return (
+        <input
+            className={'line-item-row-input quantity-received-input form-control ' + (hasError ? 'field-validation-error' : '')}
+            value={value}
+            onChange={onValueChange}
+            pattern="[0-9]*"
+            id="quantity-received-id"
+            type="number"
+            readOnly={isReadOnly}
         />
     );
 });
@@ -145,7 +173,7 @@ export const SubtotalInput: FC<SubtotalInputProps> = memo(props => {
 });
 
 export const ControlledSubstance: FC<InputProps> = memo(props => {
-    const { onChange, value } = props;
+    const { onChange, value, isReadOnly } = props;
 
     const onInputChange = useCallback(
         evt => {
@@ -161,6 +189,7 @@ export const ControlledSubstance: FC<InputProps> = memo(props => {
             checked={value}
             onChange={onInputChange}
             id="control-substance-id"
+            disabled={isReadOnly}
         />
     );
 });

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
@@ -29,7 +29,7 @@ export const DescriptionInput: FC<InputProps> = memo(props => {
             value={value}
             onChange={onTextChange}
             id="item-description-id"
-            readOnly={isReadOnly}
+            disabled={isReadOnly}
         />
     );
 });
@@ -115,13 +115,13 @@ export const UnitQuantityInput: FC<NumericInputProps> = memo(props => {
             pattern="[0-9]*"
             id="unit-quantity-id"
             type="number"
-            readOnly={isReadOnly}
+            disabled={isReadOnly}
         />
     );
 });
 
 export const QuantityReceivedInput: FC<NumericInputProps> = memo(props => {
-    const { onChange, value, hasError, isReadOnly } = props;
+    const { onChange, value, hasError } = props;
 
     const onValueChange = useCallback(
         evt => {
@@ -138,7 +138,6 @@ export const QuantityReceivedInput: FC<NumericInputProps> = memo(props => {
             pattern="[0-9]*"
             id="quantity-received-id"
             type="number"
-            readOnly={isReadOnly}
         />
     );
 });

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
@@ -81,7 +81,7 @@ export const UnitCostInput: FC<NumericInputProps> = memo(props => {
 
     const onValueChange = useCallback(
         evt => {
-            onChange('unitCost', evt.target.value);
+            onChange?.('unitCost', evt.target.value);
         },
         [onChange]
     );
@@ -103,7 +103,7 @@ export const UnitQuantityInput: FC<NumericInputProps> = memo(props => {
 
     const onValueChange = useCallback(
         evt => {
-            onChange('quantity', evt.target.value);
+            onChange?.('quantity', evt.target.value);
         },
         [onChange]
     );
@@ -126,7 +126,7 @@ export const QuantityReceivedInput: FC<NumericInputProps> = memo(props => {
 
     const onValueChange = useCallback(
         evt => {
-            onChange('quantityReceived', evt.target.value);
+            onChange?.('quantityReceived', evt.target.value);
         },
         [onChange]
     );
@@ -177,7 +177,7 @@ export const ControlledSubstance: FC<InputProps> = memo(props => {
 
     const onInputChange = useCallback(
         evt => {
-            onChange('controlledSubstance', evt.target.checked);
+            onChange?.('controlledSubstance', evt.target.checked);
         },
         [onChange]
     );

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
@@ -73,6 +73,7 @@ interface NumericInputProps {
     onChange?: (colName, value) => void;
     hasError?: boolean;
     isReadOnly?: boolean;
+    hidden?: boolean;
 }
 
 export const UnitCostInput: FC<NumericInputProps> = memo(props => {

--- a/WNPRC_Purchasing/src/client/components/PurchaseAdminPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/PurchaseAdminPanel.tsx
@@ -41,7 +41,7 @@ export const PurchaseAdminPanel: FC<Props> = memo(props => {
         >
             <div className="bg-primary">
                 <Panel.Heading>
-                    <div className="panel-title">Purchase Admin Input</div>
+                    <div className="panel-title">Purchasing Details (for internal use)</div>
                 </Panel.Heading>
             </div>
             <Form className="form-margin">

--- a/WNPRC_Purchasing/src/client/components/RequestOrderPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/RequestOrderPanel.tsx
@@ -72,7 +72,7 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
                 >
                     <div className="bg-primary">
                         <Panel.Heading>
-                            <div className="panel-title">Request Order</div>
+                            <div className="panel-title">Request Info</div>
                         </Panel.Heading>
                     </div>
                     <Form className="form-margin">
@@ -115,7 +115,7 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
                 >
                     <div className="bg-primary">
                         <Panel.Heading>
-                            <div className="panel-title">Request Order</div>
+                            <div className="panel-title">Request Info</div>
                         </Panel.Heading>
                     </div>
                     <Form className="form-margin">

--- a/WNPRC_Purchasing/src/client/components/RequestOrderPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/RequestOrderPanel.tsx
@@ -63,8 +63,7 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
 
     return (
         <>
-        {
-            !isAdmin && canUpdate && (
+        { !isAdmin && canUpdate && (
                 <Panel
                     className="panel panel-default"
                     expanded={true}
@@ -106,8 +105,7 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
                 </Panel>
             )
         }
-        {
-            (isAdmin || !canUpdate) && (
+        { (isAdmin || !canUpdate) && (
                 <Panel
                     className="panel panel-default"
                     expanded={true}

--- a/WNPRC_Purchasing/src/client/components/RequestOrderPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/RequestOrderPanel.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useState } from 'react';
+import React, {FC, memo, useCallback, useEffect, useState} from 'react';
 import { Form, Panel, Row, Col } from 'react-bootstrap';
 
 import produce, { Draft } from 'immer';
@@ -18,10 +18,12 @@ import {
 interface Props {
     model: RequestOrderModel;
     onInputChange: (model: RequestOrderModel) => void;
+    isAdmin: boolean;
+    canUpdate: boolean;
 }
 
 export const RequestOrderPanel: FC<Props> = memo(props => {
-    const { model, onInputChange } = props;
+    const { model, onInputChange, isAdmin, canUpdate } = props;
 
     const [showOtherAcct, setShowOtherAcct] = useState<boolean>(false);
 
@@ -60,111 +62,121 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
     );
 
     return (
-        <Panel
-            className="panel panel-default"
-            expanded={true}
-            onToggle={function () {}} // this is added to suppress JS warning about providing an expanded prop without onToggle
-        >
-            <div className="bg-primary">
-                <Panel.Heading>
-                    <div className="panel-title">Request Order</div>
-                </Panel.Heading>
-            </div>
-            <Form className="form-margin">
-                <Row>
-                    <Col xs={11} lg={6}>
-                        <AccountInput
-                            value={model.account}
-                            hasError={model.errors?.find(field => field.fieldName === 'account')}
-                            onChange={onValueChange}
-                        />
-                        {(showOtherAcct || model.account === 'Other') && (
-                            <AccountOtherInput
-                                value={model.otherAcctAndInves}
-                                hasError={model.errors?.find(field => field.fieldName === 'otherAcctAndInves')}
-                                hasOtherAcctWarning={!!model.otherAcctAndInvesWarning}
-                                onChange={onValueChange}
-                            />
-                        )}
-                    </Col>
-                    <Col xs={11} lg={6}>
-                        <ShippingDestinationInput
-                            value={model.shippingInfoId}
-                            hasError={model.errors?.find(field => field.fieldName === 'shippingInfoId')}
-                            onChange={onValueChange}
-                        />
-                    </Col>
-                </Row>
-                <Row>
-                    <Col xs={11} lg={6}>
-                        <VendorInput
-                            hasError={model.errors?.find(field => field.fieldName === 'vendorId')}
-                            onChange={onValueChange}
-                            model={model}
-                            onModelChange={onModelChange}
-                        />
-                    </Col>
-                    <Col xs={11} lg={6}>
-                        <DeliveryAttentionInput
-                            value={model.shippingAttentionTo}
-                            hasError={model.errors?.find(field => field.fieldName === 'shippingAttentionTo')}
-                            onChange={onValueChange}
-                        />
-                    </Col>
-                </Row>
-                <Row>
-                    <Col xs={11} lg={6}>
-                        <BusinessPurposeInput
-                            value={model.justification}
-                            hasError={model.errors?.find(field => field.fieldName === 'justification')}
-                            onChange={onValueChange}
-                        />
-                    </Col>
-                    <Col xs={11} lg={6}>
-                        <SpecialInstructionInput value={model.comments} onChange={onValueChange} />
-                    </Col>
-                </Row>
-                {/* <AccountInput*/}
-                {/*    value={model.account}*/}
-                {/*    hasError={model.errors?.find((field) => field.fieldName === 'account')}*/}
-                {/*    onChange={onValueChange}*/}
-                {/* />*/}
-                {/* {*/}
-                {/*    (showOtherAcct || model.account === "Other") &&*/}
-                {/*    <AccountOtherInput*/}
-                {/*            value={model.otherAcctAndInves}*/}
-                {/*            hasError={model.errors?.find((field) => field.fieldName === 'otherAcctAndInves')}*/}
-                {/*            hasOtherAcctWarning={!!model.otherAcctAndInvesWarning}*/}
-                {/*            onChange={onValueChange}*/}
-                {/*    />*/}
-                {/* }*/}
-                {/* <VendorInput*/}
-                {/*    hasError={model.errors?.find((field) => field.fieldName === 'vendorId')}*/}
-                {/*    onChange={onValueChange}*/}
-                {/*    model={model}*/}
-                {/*    onModelChange={onModelChange}*/}
-                {/* />*/}
-                {/* <BusinessPurposeInput*/}
-                {/*    value={model.justification}*/}
-                {/*    hasError={model.errors?.find((field) => field.fieldName === 'justification')}*/}
-                {/*    onChange={onValueChange}*/}
-                {/* />*/}
-                {/* <SpecialInstructionInput*/}
-                {/*    value={model.comments}*/}
-                {/*    onChange={onValueChange}*/}
-                {/* />*/}
-                {/* <ShippingDestinationInput*/}
-                {/*    value={model.shippingInfoId}*/}
-                {/*    hasError={model.errors?.find((field) => field.fieldName === 'shippingInfoId')}*/}
-                {/*    onChange={onValueChange}*/}
-                {/* />*/}
-                {/* <DeliveryAttentionInput*/}
-                {/*    value={model.shippingAttentionTo}*/}
-                {/*    hasError={model.errors?.find((field) => field.fieldName === 'shippingAttentionTo')}*/}
-                {/*    onChange={onValueChange}*/}
-                {/* />*/}
-            </Form>
-            {model.errorMsg && <div className="alert alert-danger">{model.errorMsg}</div>}
-        </Panel>
+        <>
+        {
+            !isAdmin && canUpdate && (
+                <Panel
+                    className="panel panel-default"
+                    expanded={true}
+                    onToggle={function () {}} // this is added to suppress JS warning about providing an expanded prop without onToggle
+                >
+                    <div className="bg-primary">
+                        <Panel.Heading>
+                            <div className="panel-title">Request Order</div>
+                        </Panel.Heading>
+                    </div>
+                    <Form className="form-margin">
+                        <Row>
+                            <Col xs={11} lg={6}>
+                                <VendorInput
+                                    model={model}
+                                    isReadOnly={true}
+                                />
+                            </Col>
+                            <Col xs={11} lg={6}>
+                                <ShippingDestinationInput
+                                    value={model.shippingInfoId}
+                                    isReadOnly={true}
+                                />
+                            </Col>
+                            <Col xs={11} lg={6}>
+                                <DeliveryAttentionInput
+                                    value={model.shippingAttentionTo}
+                                    isReadOnly={true}
+                                />
+                            </Col>
+                            <Col xs={11} lg={6}>
+                                <SpecialInstructionInput
+                                    value={model.comments}
+                                    isReadOnly={true}
+                                />
+                            </Col>
+                        </Row>
+                    </Form>
+                </Panel>
+            )
+        }
+        {
+            (isAdmin || !canUpdate) && (
+                <Panel
+                    className="panel panel-default"
+                    expanded={true}
+                    onToggle={function () {}} // this is added to suppress JS warning about providing an expanded prop without onToggle
+                >
+                    <div className="bg-primary">
+                        <Panel.Heading>
+                            <div className="panel-title">Request Order</div>
+                        </Panel.Heading>
+                    </div>
+                    <Form className="form-margin">
+                        <Row>
+                            <Col xs={11} lg={6}>
+                                <AccountInput
+                                    value={model.account}
+                                    hasError={model.errors?.find(field => field.fieldName === 'account')}
+                                    onChange={onValueChange}
+                                />
+                                {(showOtherAcct || model.account === 'Other') && (
+                                    <AccountOtherInput
+                                        value={model.otherAcctAndInves}
+                                        hasError={model.errors?.find(field => field.fieldName === 'otherAcctAndInves')}
+                                        hasOtherAcctWarning={!!model.otherAcctAndInvesWarning}
+                                        onChange={onValueChange}
+                                    />
+                                )}
+                            </Col>
+                            <Col xs={11} lg={6}>
+                                <ShippingDestinationInput
+                                    value={model.shippingInfoId}
+                                    hasError={model.errors?.find(field => field.fieldName === 'shippingInfoId')}
+                                    onChange={onValueChange}
+                                />
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col xs={11} lg={6}>
+                                <VendorInput
+                                    hasError={model.errors?.find(field => field.fieldName === 'vendorId')}
+                                    onChange={onValueChange}
+                                    model={model}
+                                    onModelChange={onModelChange}
+                                />
+                            </Col>
+                            <Col xs={11} lg={6}>
+                                <DeliveryAttentionInput
+                                    value={model.shippingAttentionTo}
+                                    hasError={model.errors?.find(field => field.fieldName === 'shippingAttentionTo')}
+                                    onChange={onValueChange}
+                                />
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col xs={11} lg={6}>
+                                <BusinessPurposeInput
+                                    value={model.justification}
+                                    hasError={model.errors?.find(field => field.fieldName === 'justification')}
+                                    onChange={onValueChange}
+                                />
+                            </Col>
+                            <Col xs={11} lg={6}>
+                                <SpecialInstructionInput value={model.comments} onChange={onValueChange} />
+                            </Col>
+                        </Row>
+                    </Form>
+                    {model.errorMsg && <div className="alert alert-danger">{model.errorMsg}</div>}
+                </Panel>
+            )
+        }
+        </>
     );
 });

--- a/WNPRC_Purchasing/src/client/components/RequestOrderPanelInputs.tsx
+++ b/WNPRC_Purchasing/src/client/components/RequestOrderPanelInputs.tsx
@@ -14,9 +14,10 @@ import { VendorPopupModal } from './VendorInputModal';
 
 interface InputProps {
     value: any;
-    onChange: (colName, value) => void;
+    onChange?: (colName, value) => void;
     hasError?: boolean;
     hasOtherAcctWarning?: boolean;
+    isReadOnly?: boolean;
 }
 
 export const AccountInput: FC<InputProps> = memo(props => {
@@ -86,14 +87,15 @@ export const AccountOtherInput: FC<InputProps> = memo(props => {
 });
 
 interface VendorInputProps {
-    onChange: (colName, value) => void;
+    onChange?: (colName, value) => void;
     hasError?: boolean;
     model: RequestOrderModel;
-    onModelChange: (model: RequestOrderModel) => void;
+    onModelChange?: (model: RequestOrderModel) => void;
+    isReadOnly?: boolean;
 }
 
 export const VendorInput: FC<VendorInputProps> = memo(props => {
-    const { onChange, hasError, model, onModelChange } = props;
+    const { onChange, hasError, model, onModelChange, isReadOnly } = props;
     const [dropDownVals, setDropDownVals] = useState<any[]>();
     const [showPopup, setShowPopup] = useState<boolean>(false);
 
@@ -158,6 +160,7 @@ export const VendorInput: FC<VendorInputProps> = memo(props => {
                     className={'vendor-input form-control ' + (hasError ? 'field-validation-error' : '')}
                     value={model.vendorId}
                     onChange={onValueChange}
+                    disabled={isReadOnly}
                 >
                     <option hidden value="">
                         Select
@@ -217,7 +220,7 @@ export const BusinessPurposeInput: FC<InputProps> = memo(props => {
 });
 
 export const SpecialInstructionInput: FC<InputProps> = memo(props => {
-    const { onChange, value } = props;
+    const { onChange, value, isReadOnly } = props;
     const onTextChange = useCallback(
         evt => {
             onChange('comments', evt.target.value);
@@ -234,6 +237,7 @@ export const SpecialInstructionInput: FC<InputProps> = memo(props => {
                     onChange={onTextChange}
                     id="special-instructions-id"
                     placeholder="Please add any special instructions or comments (Optional)"
+                    readOnly={isReadOnly}
                 />
             </PurchasingFormInput>
         </div>
@@ -241,7 +245,7 @@ export const SpecialInstructionInput: FC<InputProps> = memo(props => {
 });
 
 export const ShippingDestinationInput: FC<InputProps> = memo(props => {
-    const { onChange, value, hasError } = props;
+    const { onChange, value, hasError, isReadOnly } = props;
     const [dropDownVals, setDropDownVals] = useState<any[]>();
 
     useEffect(() => {
@@ -268,8 +272,9 @@ export const ShippingDestinationInput: FC<InputProps> = memo(props => {
                     className={'shipping-dest-input form-control ' + (hasError ? 'field-validation-error' : '')}
                     value={value}
                     onChange={onValueChange}
+                    disabled={isReadOnly}
                 >
-                    <option hidden value="">
+                    <option hidden value="" disabled={isReadOnly}>
                         Select
                     </option>
                     {options}
@@ -280,7 +285,7 @@ export const ShippingDestinationInput: FC<InputProps> = memo(props => {
 });
 
 export const DeliveryAttentionInput: FC<InputProps> = memo(props => {
-    const { onChange, value, hasError } = props;
+    const { onChange, value, hasError, isReadOnly } = props;
     const onTextChange = useCallback(
         evt => {
             onChange('shippingAttentionTo', evt.target.value);
@@ -296,6 +301,7 @@ export const DeliveryAttentionInput: FC<InputProps> = memo(props => {
                     onChange={onTextChange}
                     id="delivery-attn-id"
                     placeholder="Name of the person package delivery should be addressed to (Required)"
+                    readOnly={isReadOnly}
                 />
             </PurchasingFormInput>
         </div>

--- a/WNPRC_Purchasing/src/client/components/RequestOrderPanelInputs.tsx
+++ b/WNPRC_Purchasing/src/client/components/RequestOrderPanelInputs.tsx
@@ -136,7 +136,7 @@ export const VendorInput: FC<VendorInputProps> = memo(props => {
                     draft['vendorId'] = ''; // Reset Vendor input when user hits Cancel and doesn't enter a new vendor
                 }
             });
-            onModelChange(updatedModel);
+            onModelChange?.(updatedModel);
         },
         [onChange, hasError, model, onModelChange]
     );
@@ -147,7 +147,7 @@ export const VendorInput: FC<VendorInputProps> = memo(props => {
                 draft['newVendor'] = newVendor;
             });
             if (!newVendor.errors) {
-                onModelChange(updatedModel);
+                onModelChange?.(updatedModel);
             }
         },
         [onChange, hasError, model, onModelChange]

--- a/WNPRC_Purchasing/src/client/model.ts
+++ b/WNPRC_Purchasing/src/client/model.ts
@@ -116,6 +116,7 @@ export class LineItemModel {
     readonly controlledSubstance: boolean = false;
     readonly itemUnit: number; // rowId of ehr_purchasing.itemUnits
     readonly quantity: number;
+    readonly quantityReceived?: number;
     readonly unitCost: number;
     readonly subTotal: number = 0;
     readonly status?: string;

--- a/WNPRC_Purchasing/src/client/model.ts
+++ b/WNPRC_Purchasing/src/client/model.ts
@@ -116,7 +116,7 @@ export class LineItemModel {
     readonly controlledSubstance: boolean = false;
     readonly itemUnit: number; // rowId of ehr_purchasing.itemUnits
     readonly quantity: number;
-    readonly quantityReceived?: number;
+    readonly quantityReceived?: number = 0;
     readonly unitCost: number;
     readonly subTotal: number = 0;
     readonly status?: string;
@@ -164,5 +164,23 @@ export class DocumentAttachmentModel {
 
     static create(raw?: any): DocumentAttachmentModel {
         return new DocumentAttachmentModel({ ...raw });
+    }
+}
+
+export class QCStateModel {
+    /**
+     * @hidden
+     */
+    [immerable] = true;
+
+    readonly rowId: number;
+    readonly label: string;
+
+    constructor(values?: Partial<QCStateModel>) {
+        Object.assign(this, values);
+    }
+
+    static create(raw?: any): QCStateModel {
+        return new QCStateModel({ ...raw });
     }
 }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
@@ -57,6 +57,7 @@ public class WNPRC_PurchasingController extends SpringActionController
         {
             WebPartFactory factory = Portal.getPortalPartCaseInsensitive("WNPRC Purchasing Requester");
             Portal.WebPart part = factory.createWebPart();
+            getPageConfig().setTitle("Purchasing Requester");
             return Portal.getWebPartViewSafe(factory, getViewContext(), part);
         }
 
@@ -69,6 +70,7 @@ public class WNPRC_PurchasingController extends SpringActionController
         public ModelAndView getView(Object o, BindException errors)
         {
             WebPartFactory factory = Portal.getPortalPartCaseInsensitive("WNPRC Purchasing Admin");
+            getPageConfig().setTitle("Purchasing Admin");
             Portal.WebPart part = factory.createWebPart();
             return Portal.getWebPartViewSafe(factory, getViewContext(), part);
         }
@@ -82,6 +84,7 @@ public class WNPRC_PurchasingController extends SpringActionController
         public ModelAndView getView(Object o, BindException errors)
         {
             WebPartFactory factory = Portal.getPortalPartCaseInsensitive("WNPRC Purchasing Receiver");
+            getPageConfig().setTitle("Purchasing Receiver");
             Portal.WebPart part = factory.createWebPart();
             return Portal.getWebPartViewSafe(factory, getViewContext(), part);
         }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
@@ -30,6 +30,7 @@ import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.WebPartFactory;
@@ -49,7 +50,7 @@ public class WNPRC_PurchasingController extends SpringActionController
         setActionResolver(_actionResolver);
     }
 
-    @RequiresPermission(ReadPermission.class)
+    @RequiresPermission(InsertPermission.class)
     public class RequesterAction extends SimpleViewAction
     {
         public ModelAndView getView(Object o, BindException errors)
@@ -68,6 +69,19 @@ public class WNPRC_PurchasingController extends SpringActionController
         public ModelAndView getView(Object o, BindException errors)
         {
             WebPartFactory factory = Portal.getPortalPartCaseInsensitive("WNPRC Purchasing Admin");
+            Portal.WebPart part = factory.createWebPart();
+            return Portal.getWebPartViewSafe(factory, getViewContext(), part);
+        }
+
+        public void addNavTrail(NavTree root) { }
+    }
+
+    @RequiresPermission(UpdatePermission.class)
+    public class PurchaseReceiverAction extends SimpleViewAction
+    {
+        public ModelAndView getView(Object o, BindException errors)
+        {
+            WebPartFactory factory = Portal.getPortalPartCaseInsensitive("WNPRC Purchasing Receiver");
             Portal.WebPart part = factory.createWebPart();
             return Portal.getWebPartViewSafe(factory, getViewContext(), part);
         }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
@@ -277,9 +277,9 @@ public class WNPRC_PurchasingManager
                 else
                     row.put("quantity", lineItem.get("quantity"));
 
-                if (Integer.valueOf(String.valueOf(lineItem.get("quantityReceived"))) < 0)
+                if (null != lineItem.get("quantityReceived") && Integer.valueOf(String.valueOf(lineItem.get("quantityReceived"))) < 0)
                     lineItemErrors.addError(new PropertyValidationError("'Quantity received' value cannot be negative.", "quantityReceived"));
-                else
+                else if (null != lineItem.get("quantityReceived"))
                     row.put("quantityReceived", lineItem.get("quantityReceived"));
 
                 //if errors, then return errors

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
@@ -284,6 +284,7 @@ public class WNPRC_PurchasingManager
                 }
 
                 row.put("controlledSubstance", lineItem.get("controlledSubstance"));
+                row.put("quantityReceived", lineItem.get("quantityReceived"));
 
                 if(null != lineItem.get("rowId"))
                 {

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
@@ -272,8 +272,15 @@ public class WNPRC_PurchasingManager
 
                 if (null == lineItem.get("quantity"))
                     lineItemErrors.addError(new PropertyValidationError("Required numeric value for 'Quantity' not provided", "quantity"));
+                else if (Integer.valueOf(String.valueOf(lineItem.get("quantity"))) < 0)
+                    lineItemErrors.addError(new PropertyValidationError("'Quantity' value cannot be negative.", "quantity"));
                 else
                     row.put("quantity", lineItem.get("quantity"));
+
+                if (Integer.valueOf(String.valueOf(lineItem.get("quantityReceived"))) < 0)
+                    lineItemErrors.addError(new PropertyValidationError("'Quantity received' value cannot be negative.", "quantityReceived"));
+                else
+                    row.put("quantityReceived", lineItem.get("quantityReceived"));
 
                 //if errors, then return errors
                 if(lineItemErrors.hasErrors())
@@ -284,7 +291,6 @@ public class WNPRC_PurchasingManager
                 }
 
                 row.put("controlledSubstance", lineItem.get("controlledSubstance"));
-                row.put("quantityReceived", lineItem.get("quantityReceived"));
 
                 if(null != lineItem.get("rowId"))
                 {

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/table/WNPRC_PurchasingCustomizer.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/table/WNPRC_PurchasingCustomizer.java
@@ -8,6 +8,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.ldk.table.AbstractTableCustomizer;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.ExprColumn;
+import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 
 import java.util.Objects;
@@ -25,16 +26,29 @@ public class WNPRC_PurchasingCustomizer extends AbstractTableCustomizer
                 addRequestLink((AbstractTableInfo) tableInfo);
                 addTotalCostColumn((AbstractTableInfo) tableInfo);
             }
+            else if (matches(tableInfo, "ehr_purchasing", "purchasingReceiverOverview"))
+            {
+                addRequestUpdateLinks((AbstractTableInfo) tableInfo);
+            }
         }
     }
 
     private void addRequestLink(AbstractTableInfo ti)
     {
-        if (ti.hasPermission(Objects.requireNonNull(ti.getUserSchema()).getUser(), UpdatePermission.class))
+        if (ti.hasPermission(Objects.requireNonNull(ti.getUserSchema()).getUser(), AdminPermission.class))
         {
             MutableColumnInfo rowId = (MutableColumnInfo) ti.getColumn("rowId");
             rowId.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${rowId}"));
         }
+    }
+
+    private void addRequestUpdateLinks(AbstractTableInfo ti)
+    {
+        MutableColumnInfo requestRowId = (MutableColumnInfo) ti.getColumn("requestRowId");
+        requestRowId.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${requestRowId}"));
+
+        MutableColumnInfo quantityReceived = (MutableColumnInfo) ti.getColumn("quantityReceived");
+        quantityReceived.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${requestRowId}"));
     }
 
     private void addAttachmentsCol(AbstractTableInfo purchasingRequestsTable)

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/table/WNPRC_PurchasingCustomizer.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/table/WNPRC_PurchasingCustomizer.java
@@ -10,6 +10,9 @@ import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.view.ActionURL;
+import org.labkey.wnprc_purchasing.WNPRC_PurchasingController;
 
 import java.util.Objects;
 
@@ -37,20 +40,28 @@ public class WNPRC_PurchasingCustomizer extends AbstractTableCustomizer
     {
         if (ti.hasPermission(Objects.requireNonNull(ti.getUserSchema()).getUser(), AdminPermission.class))
         {
-            String returnUrl = ti.getUserSchema().getContainer().getPath() + "/WNPRC_Purchasing-purchaseAdmin.view?";
+            ActionURL returnUrl = new ActionURL(WNPRC_PurchasingController.PurchaseAdminAction.class, ti.getUserSchema().getContainer());
+            ActionURL detailsUrl = new ActionURL(WNPRC_PurchasingController.PurchasingRequestAction.class, ti.getUserSchema().getContainer());
+            detailsUrl.addParameter("requestRowId", "${rowId}");
+            detailsUrl.addParameter("returnUrl", returnUrl.getPath());
+
             MutableColumnInfo rowId = (MutableColumnInfo) ti.getColumn("rowId");
-            rowId.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${rowId}&returnUrl="+returnUrl));
+            rowId.setURL(DetailsURL.fromString(detailsUrl.toContainerRelativeURL()));
         }
     }
 
     private void addRequestUpdateLinks(AbstractTableInfo ti)
     {
-        String returnUrl = ti.getUserSchema().getContainer().getPath() + "/WNPRC_Purchasing-purchaseReceiver.view?";
+        ActionURL returnUrl = new ActionURL(WNPRC_PurchasingController.PurchaseReceiverAction.class, ti.getUserSchema().getContainer());
+        ActionURL detailsUrl = new ActionURL(WNPRC_PurchasingController.PurchasingRequestAction.class, ti.getUserSchema().getContainer());
+        detailsUrl.addParameter("requestRowId", "${requestRowId}");
+        detailsUrl.addParameter("returnUrl", returnUrl.getPath());
+
         MutableColumnInfo requestRowId = (MutableColumnInfo) ti.getColumn("requestRowId");
-        requestRowId.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${requestRowId}&returnUrl="+returnUrl));
+        requestRowId.setURL(DetailsURL.fromString(detailsUrl.toContainerRelativeURL()));
 
         MutableColumnInfo quantityReceived = (MutableColumnInfo) ti.getColumn("quantityReceived");
-        quantityReceived.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${requestRowId}&returnUrl="+returnUrl));
+        quantityReceived.setURL(DetailsURL.fromString(detailsUrl.toContainerRelativeURL()));
     }
 
     private void addAttachmentsCol(AbstractTableInfo purchasingRequestsTable)

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/table/WNPRC_PurchasingCustomizer.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/table/WNPRC_PurchasingCustomizer.java
@@ -37,18 +37,20 @@ public class WNPRC_PurchasingCustomizer extends AbstractTableCustomizer
     {
         if (ti.hasPermission(Objects.requireNonNull(ti.getUserSchema()).getUser(), AdminPermission.class))
         {
+            String returnUrl = ti.getUserSchema().getContainer().getPath() + "/WNPRC_Purchasing-purchaseAdmin.view?";
             MutableColumnInfo rowId = (MutableColumnInfo) ti.getColumn("rowId");
-            rowId.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${rowId}"));
+            rowId.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${rowId}&returnUrl="+returnUrl));
         }
     }
 
     private void addRequestUpdateLinks(AbstractTableInfo ti)
     {
+        String returnUrl = ti.getUserSchema().getContainer().getPath() + "/WNPRC_Purchasing-purchaseReceiver.view?";
         MutableColumnInfo requestRowId = (MutableColumnInfo) ti.getColumn("requestRowId");
-        requestRowId.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${requestRowId}"));
+        requestRowId.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${requestRowId}&returnUrl="+returnUrl));
 
         MutableColumnInfo quantityReceived = (MutableColumnInfo) ti.getColumn("quantityReceived");
-        quantityReceived.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${requestRowId}"));
+        quantityReceived.setURL(DetailsURL.fromString("/WNPRC_Purchasing-purchasingRequest.view?requestRowId=${requestRowId}&returnUrl="+returnUrl));
     }
 
     private void addAttachmentsCol(AbstractTableInfo purchasingRequestsTable)

--- a/WNPRC_Purchasing/test/src/org/labkey/test/Pages/CreateRequestPage.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/Pages/CreateRequestPage.java
@@ -127,7 +127,7 @@ public class CreateRequestPage extends LabKeyPage<CreateRequestPage.ElementCache
         return this;
     }
 
-    public CreateRequestPage submitExpectingError()
+    public CreateRequestPage submitForReviewExpectingError()
     {
         elementCache().submitForReview.click();
         clearCache();
@@ -143,7 +143,7 @@ public class CreateRequestPage extends LabKeyPage<CreateRequestPage.ElementCache
 
     public CreateRequestPage submit()
     {
-        clickAndWait(Locator.button("Submit").findElement(getDriver()));
+        clickAndWait(elementCache().submit);
         return this;
     }
     public CreateRequestPage cancel()
@@ -165,7 +165,7 @@ public class CreateRequestPage extends LabKeyPage<CreateRequestPage.ElementCache
 
     public String getAlertMessage()
     {
-        return Locator.byClass("alert alert-danger").findWhenNeeded(getDriver()).getText();
+        return elementCache().alertMessage.getText();
     }
 
     public String getAssignedTo()
@@ -258,6 +258,16 @@ public class CreateRequestPage extends LabKeyPage<CreateRequestPage.ElementCache
         return this;
     }
 
+    public CreateRequestPage setQuantityReceived(String value)
+    {
+        setFormElement(Locator.id("quantity-received-id"),value);
+        return this;
+    }
+
+    public String getQuantityReceived()
+    {
+        return Locator.id("quantity-received-id").findElement(getDriver()).getText();
+    }
     @Override
     protected CreateRequestPage.ElementCache newElementCache()
     {
@@ -283,7 +293,9 @@ public class CreateRequestPage extends LabKeyPage<CreateRequestPage.ElementCache
         final WebElement attachment = Locator.id("fileUpload").findWhenNeeded(this).withTimeout(200);
 
         final WebElement submitForReview = Locator.button("Submit for Review").findWhenNeeded(this);
+        final WebElement submit = Locator.button("Submit").findWhenNeeded(this);
         final WebElement cancel = Locator.button("Cancel").findWhenNeeded(this);
+        final WebElement alertMessage = Locator.byClass("alert alert-danger").findWhenNeeded(this);
         final Select accountToCharge = SelectWrapper.Select(Locator.byClass("account-input form-control "))
                 .findWhenNeeded(this);
         final Select vendor = SelectWrapper.Select(Locator.byClass("vendor-input form-control "))

--- a/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
@@ -70,6 +70,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
 
     //users
     private static final String REQUESTER_USER = "purchaserequester@test.com";
+    private static final String RECEIVER_USER = "purchasereceiver@test.com";
     private static final String requesterName = "purchaserequester";
     private static final String ADMIN_USER = "purchaseadmin@test.com";
     //other properties
@@ -87,6 +88,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
     ApiPermissionsHelper _apiPermissionsHelper = new ApiPermissionsHelper(this);
     private int _adminUserId;
     private int _requesterUserId;
+    private int _receiverUserId;
     private SchemaHelper _schemaHelper = new SchemaHelper(this);
     private UIPermissionsHelper _permissionsHelper = new UIPermissionsHelper(this);
 
@@ -113,6 +115,9 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
 
         log("Create a purchasing requester user");
         _requesterUserId = _userHelper.createUser(REQUESTER_USER).getUserId().intValue();
+
+        log("Create a purchasing receiver user");
+        _receiverUserId = _userHelper.createUser(RECEIVER_USER).getUserId().intValue();
 
         goToHome();
 
@@ -157,6 +162,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         _permissionsHelper.setUserPermissions(getCurrentUser(), "Project Administrator");
         _permissionsHelper.setUserPermissions(REQUESTER_USER, "Submitter");
         _permissionsHelper.setUserPermissions(REQUESTER_USER, "Reader");
+        _permissionsHelper.setUserPermissions(RECEIVER_USER, "Editor");
     }
 
     private void goToPurchaseAdminPage()


### PR DESCRIPTION
#### Rationale
* Features for the Receiving clerk to be able to search line items by the vendor name, item description, purchase order number, Invoice Number, or confirmation number. Also, allow to update 'quantity received' for a particular line item and upload attachments such as packing slips.
Spec [here](https://docs.google.com/document/d/17S6R7jDa3E2JlN4w3Rz5ADLrimem3RcmgomFYB-2huI/edit#).

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/162

#### Changes
* Add Receiver's webpart
* Add action to render Receiver webpart
* Add Purchasing Receiver's link on main wnprcUnits page
* Remove Issues link from wnprcUnits and add to Purchase Admin page
* Add quantityReceived to the data entry page
* Conditionalize the data entry form based on user perms
* Handle qcstate upon quantity received