### PR TITLE
Epic 8493: WNPRC Purchasing Email Notification

### DIFF
--- a/WNPRC_Purchasing/resources/data/paymentOptions.tsv
+++ b/WNPRC_Purchasing/resources/data/paymentOptions.tsv
@@ -1,7 +1,7 @@
 paymentOption
 Internal PO
 External PO
-MDS
+Shop UW+
 Blanket Order
 Direct Payment
 Purchasing Card

--- a/WNPRC_Purchasing/resources/lineItemsChange.txt
+++ b/WNPRC_Purchasing/resources/lineItemsChange.txt
@@ -8,7 +8,9 @@ table, td {
 </head>
 <body>
 <div>
-    <p>Your purchase request# ^requestNum^ from vendor ^vendor^ submitted on ^created^ has been modified.</p>
+    <p>Your purchase request# ^requestNum^ from vendor ^vendor^ submitted on ^created^ has been updated.</p>
+    <p>^hasFullQuantityReceived^</p>
+    <p><i>^hasDeletedLineItems^</i></p>
     <br>
     <b>Updated line items:</b>
     <br>
@@ -26,7 +28,7 @@ table, td {
 
 <div>
     <br>
-    <b>Previously saved line items:</b>
+    <b>Old line item:</b>
     <br>
 </div>
 <table width="500px">
@@ -41,7 +43,7 @@ table, td {
 </table>
 
 <br>
-View full request <a href="^requestDataEntryUrl^">here</a>.
+View your request details <a href="^requestDataEntryUrl^">here</a>.
 <br>
 </body>
 </html>

--- a/WNPRC_Purchasing/resources/lineItemsChange.txt
+++ b/WNPRC_Purchasing/resources/lineItemsChange.txt
@@ -28,7 +28,7 @@ table, td {
 
 <div>
     <br>
-    <b>Old line item:</b>
+    <b>Old line items:</b>
     <br>
 </div>
 <table width="500px">

--- a/WNPRC_Purchasing/resources/lineItemsChange.txt
+++ b/WNPRC_Purchasing/resources/lineItemsChange.txt
@@ -8,7 +8,7 @@ table, td {
 </head>
 <body>
 <div>
-    <p>Your purchase request# ^requestNum^ from vendor ^vendor^ submitted on ^created^ has been updated.</p>
+    <p>Your purchase request # ^requestNum^ from vendor ^vendor^ submitted on ^created^ has been updated.</p>
     <p>^hasFullQuantityReceived^</p>
     <p><i>^hasDeletedLineItems^</i></p>
     <br>

--- a/WNPRC_Purchasing/resources/lineItemsChange.txt
+++ b/WNPRC_Purchasing/resources/lineItemsChange.txt
@@ -1,0 +1,52 @@
+<html>
+<body>
+<div>
+    <p>Your purchase request ^requestNum^ from vendor ^vendor^ submitted on ^created^ has been modified.</p>
+    <br>
+    Updated line items:
+    <br>
+</div>
+<table width="500px">
+    <tr>
+        <td valign="top"><b>Item id</b></td>
+    </tr>
+    <tr>
+        <td valign="top"><b>Description</b></td>
+    </tr>
+    <tr>
+        <td valign="top"><b>Unit cost</b></td>
+    </tr>
+    <tr>
+        <td valign="top"><b>Quantity</b></td>
+    </tr>
+    <tr>
+        <td valign="top"><b>Quantity received</b></td>
+    </tr>
+    ^updatedLineItems^
+</table>
+
+<div>
+    <br>
+    Previously saved line items:
+    <br>
+</div>
+<table width="500px">
+    <tr>
+        <td valign="top"><b>Item id</b></td>
+    </tr>
+    <tr>
+        <td valign="top"><b>Description</b></td>
+    </tr>
+    <tr>
+        <td valign="top"><b>Unit cost</b></td>
+    </tr>
+    <tr>
+        <td valign="top"><b>Quantity</b></td>
+    </tr>
+    <tr>
+        <td valign="top"><b>Quantity received</b></td>
+    </tr>
+    ^oldLineItems^
+</table>
+</body>
+</html>

--- a/WNPRC_Purchasing/resources/lineItemsChange.txt
+++ b/WNPRC_Purchasing/resources/lineItemsChange.txt
@@ -1,52 +1,47 @@
 <html>
+<head>
+<style>
+table, td {
+  border: 0.25px solid gray;
+}
+</style>
+</head>
 <body>
 <div>
-    <p>Your purchase request ^requestNum^ from vendor ^vendor^ submitted on ^created^ has been modified.</p>
+    <p>Your purchase request# ^requestNum^ from vendor ^vendor^ submitted on ^created^ has been modified.</p>
     <br>
-    Updated line items:
+    <b>Updated line items:</b>
     <br>
 </div>
 <table width="500px">
     <tr>
-        <td valign="top"><b>Item id</b></td>
+        <td valign="top" style="width: 100px"><b>Item id</b></td>
+        <td valign="top" style="width: 600px"><b>Description</b></td>
+        <td valign="top" style="width: 200px"><b>Unit cost</b></td>
+        <td valign="top" style="width: 100px"><b>Quantity</b></td>
+        <td valign="top" style="width: 100px"><b>Quantity received</b></td>
     </tr>
-    <tr>
-        <td valign="top"><b>Description</b></td>
-    </tr>
-    <tr>
-        <td valign="top"><b>Unit cost</b></td>
-    </tr>
-    <tr>
-        <td valign="top"><b>Quantity</b></td>
-    </tr>
-    <tr>
-        <td valign="top"><b>Quantity received</b></td>
-    </tr>
-    ^updatedLineItems^
+     ^updatedLineItems^
 </table>
 
 <div>
     <br>
-    Previously saved line items:
+    <b>Previously saved line items:</b>
     <br>
 </div>
 <table width="500px">
     <tr>
-        <td valign="top"><b>Item id</b></td>
-    </tr>
-    <tr>
-        <td valign="top"><b>Description</b></td>
-    </tr>
-    <tr>
-        <td valign="top"><b>Unit cost</b></td>
-    </tr>
-    <tr>
-        <td valign="top"><b>Quantity</b></td>
-    </tr>
-    <tr>
-        <td valign="top"><b>Quantity received</b></td>
+        <td valign="top" style="width: 100px"><b>Item id</b></td>
+        <td valign="top" style="width: 600px"><b>Description</b></td>
+        <td valign="top" style="width: 200px"><b>Unit cost</b></td>
+        <td valign="top" style="width: 100px"><b>Quantity</b></td>
+        <td valign="top" style="width: 100px"><b>Quantity received</b></td>
     </tr>
     ^oldLineItems^
 </table>
+
+<br>
+View full request <a href="^requestDataEntryUrl^">here</a>.
+<br>
 </body>
 </html>

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingReceiverOverview.sql
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingReceiverOverview.sql
@@ -8,6 +8,8 @@ requestRowId.invoiceNum,
 quantity,
 quantityReceived,
 itemUnitId.itemUnit,
-controlledSubstance
+controlledSubstance,
+createdBy AS requester,
+created AS requestDate
 FROM ehr_purchasing.lineItems
 WHERE requestRowId.qcState.Label = 'Order Placed'

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverview.query.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverview.query.xml
@@ -7,14 +7,16 @@
                 <columns>
                     <column columnName="rowId">
                         <columnTitle>Request No.</columnTitle>
+                        <isKeyField>true</isKeyField>
                     </column>
                     <column columnName="requestDate">
                         <formatString>Date</formatString>
                     </column>
-                    <column columnName="vendorId">
+                    <column columnName="vendor">
                         <fk>
                             <fkDbSchema>ehr_purchasing</fkDbSchema>
                             <fkTable>vendor</fkTable>
+                            <fkDisplayColumnName useRawValue="false"/>
                         </fk>
                     </column>
                     <column columnName="account">
@@ -30,6 +32,7 @@
                         <fk>
                             <fkDbSchema>core</fkDbSchema>
                             <fkTable>QCState</fkTable>
+                            <fkDisplayColumnName useRawValue="false"/>
                         </fk>
                     </column>
                     <column columnName="OtherAcctAndInves"/>

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverview.query.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverview.query.xml
@@ -16,7 +16,6 @@
                         <fk>
                             <fkDbSchema>ehr_purchasing</fkDbSchema>
                             <fkTable>vendor</fkTable>
-                            <fkDisplayColumnName useRawValue="false"/>
                         </fk>
                     </column>
                     <column columnName="account">
@@ -32,7 +31,6 @@
                         <fk>
                             <fkDbSchema>core</fkDbSchema>
                             <fkTable>QCState</fkTable>
-                            <fkDisplayColumnName useRawValue="false"/>
                         </fk>
                     </column>
                     <column columnName="OtherAcctAndInves"/>

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverview.sql
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverview.sql
@@ -1,11 +1,12 @@
 -- this is the query that displays on the requesters page
 SELECT
        pr.rowId,
-       pr.vendorId,
+       pr.vendorId.vendorName AS vendor,
        pr.account,
        pr.otherAcctAndInves,
-       pr.qcState   AS requestStatus,
+       pr.qcState.Label   AS requestStatus,
        pr.created   AS requestDate,
+       pr.orderDate,
        pr.createdBy AS requester,
        pr.totalCost
 FROM ehr_purchasing.purchasingRequests pr

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverview.sql
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverview.sql
@@ -1,10 +1,10 @@
 -- this is the query that displays on the requesters page
 SELECT
        pr.rowId,
-       pr.vendorId.vendorName AS vendor,
+       pr.vendorId AS vendor,
        pr.account,
        pr.otherAcctAndInves,
-       pr.qcState.Label   AS requestStatus,
+       pr.qcState   AS requestStatus,
        pr.created   AS requestDate,
        pr.orderDate,
        pr.createdBy AS requester,

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForAdmins.query.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForAdmins.query.xml
@@ -1,7 +1,7 @@
 <query xmlns="http://labkey.org/data/xml/query">
     <metadata>
         <tables xmlns="http://labkey.org/data/xml">
-            <table tableName="purchasingRequestsOverview" tableDbType="NOT_IN_DB" useColumnOrder="true">
+            <table tableName="purchasingRequestsOverviewForAdmins" tableDbType="NOT_IN_DB" useColumnOrder="true">
                 <tableTitle>Purchase Requests</tableTitle>
             </table>
         </tables>

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForAdmins.sql
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForAdmins.sql
@@ -6,6 +6,7 @@ SELECT
        pr.qcState   AS requestStatus,
        pr.created   AS requestDate,
        pr.createdBy AS requester,
+       pr.orderDate,
        pr.totalCost,
        pr.assignedTo,
        pr.attachments

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForEmailTemplate.sql
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/purchasingRequestsOverviewForEmailTemplate.sql
@@ -1,0 +1,9 @@
+SELECT
+       pr.rowId AS requestNum,
+       pr.vendorId.vendorName AS vendor,
+       pr.qcState.Label   AS requestStatus,
+       pr.created   AS requestDate,
+       pr.createdBy AS requester,
+       pr.orderDate,
+       pr.totalCost
+FROM ehr_purchasing.purchasingRequests pr

--- a/WNPRC_Purchasing/resources/views/purchasingAdmin.html
+++ b/WNPRC_Purchasing/resources/views/purchasingAdmin.html
@@ -1,57 +1,6 @@
-<script type="text/javascript">
-
-    function goToRequestDataEntry() {
-        window.location = LABKEY.ActionURL.buildURL('WNPRC_Purchasing', 'purchasingRequest', LABKEY.ActionURL.getContainer(), {isNewRequest: true, returnUrl:window.location});
-    }
-
-    function goToVendorsView() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'vendor'});
-    }
-
-    function goToUserAccountAssociationsView() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'userAccountAssociations'});
-    }
-
-    function goToShippingInfoView() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'shippingInfo'});
-    }
-
-    function goToItemUnitsView() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'itemUnits'});
-    }
-
-    function goToLineItemsView() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'lineItems'});
-    }
-
-    function goToMyOpenRequestsView() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'myOpenRequests'});
-    }
-
-    function goToOpenRequestsView() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'purchasingRequestsOverviewForAdmins', 'query.viewName':'AllOpenRequests'});
-    }
-
-    function goToCompletedRequestsView() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'purchasingRequestsOverviewForAdmins', 'query.viewName':'CompletedRequests'});
-    }
-
-    function goToRequestsView() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'purchasingRequestsOverviewForAdmins'});
-    }
-
-    function goToPCardView() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'pCard'});
-    }
-
-    function goToPaymentOptions() {
-        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'wnprc_purchasing', 'query.queryName': 'paymentOptions'});
-    }
-</script>
-
 <div id="<%=h('wnprc_purchasing-admin-page')%>"></div>
 <h4 style="font-family: Roboto;font-size: 14px;font-weight: bold;">Purchasing Requests</h4>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToRequestDataEntry()">Enter Request</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/WNPRC_Purchasing-purchasingRequest.view?isNewRequest=true&returnUrl=<%=contextPath%><%=containerPath%>/WNPRC_Purchasing-purchaseAdmin.view?">Enter Request</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=myOpenRequests">My Open Requests</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=purchasingRequestsOverviewForAdmins&query.viewName=AllOpenRequests">All Open Requests</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=purchasingRequestsOverviewForAdmins&query.viewName=CompletedRequests">Completed Requests</a></span></div>
@@ -59,7 +8,7 @@
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=pCard">P-Card View</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%>/project/WNPRC/WNPRC_Units/Operation_Services/Purchasing/Issue_Tracker/start.view?">Issue Tracker</a></span></div>
 
-<h4 style="font-family: Roboto;font-size: 14px;font-weight: bold; padding-top:10px;">Reference Tables</h4>
+<h4 style="font-family: Roboto;font-size: 14px;font-weight: bold; padding-top:10px;">Reference Tables & Links</h4>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=vendor">Vendors</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=userAccountAssociations">User Account Associations</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=shippingInfo">Shipping Info</a></span></div>
@@ -67,3 +16,4 @@
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=lineItems">Line Items</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=wnprc_purchasing&query.queryName=paymentOptions">Payment Options</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/admin-customizeEmail.view?">Email Templates</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%>/_webdav/<%=containerPath%>/@files">Documents</a></span></div>

--- a/WNPRC_Purchasing/resources/views/purchasingAdmin.html
+++ b/WNPRC_Purchasing/resources/views/purchasingAdmin.html
@@ -43,21 +43,27 @@
     function goToPCardView() {
         window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'ehr_purchasing', 'query.queryName': 'pCard'});
     }
+
+    function goToPaymentOptions() {
+        window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', LABKEY.ActionURL.getContainer(), {schemaName: 'wnprc_purchasing', 'query.queryName': 'paymentOptions'});
+    }
 </script>
 
 <div id="<%=h('wnprc_purchasing-admin-page')%>"></div>
 <h4 style="font-family: Roboto;font-size: 14px;font-weight: bold;">Purchasing Requests</h4>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToRequestDataEntry()">Enter Request</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToMyOpenRequestsView()">My Open Requests</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToOpenRequestsView()">All Open Requests</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToCompletedRequestsView()">Completed Requests</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToRequestsView()">All Requests</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToPCardView()">P-Card View</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=myOpenRequests">My Open Requests</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=purchasingRequestsOverviewForAdmins&query.viewName=AllOpenRequests">All Open Requests</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=purchasingRequestsOverviewForAdmins&query.viewName=CompletedRequests">Completed Requests</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=purchasingRequestsOverviewForAdmins">All Requests</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=pCard">P-Card View</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%>/project/WNPRC/WNPRC_Units/Operation_Services/Purchasing/Issue_Tracker/start.view?">Issue Tracker</a></span></div>
 
 <h4 style="font-family: Roboto;font-size: 14px;font-weight: bold; padding-top:10px;">Reference Tables</h4>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToVendorsView()">Vendors</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToUserAccountAssociationsView()">User Account Associations</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToShippingInfoView()">Shipping Info</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToItemUnitsView()">Item Units</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToLineItemsView()">Line Items</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=vendor">Vendors</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=userAccountAssociations">User Account Associations</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=shippingInfo">Shipping Info</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=itemUnits">Item Units</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=lineItems">Line Items</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/query-executeQuery.view?schemaName=wnprc_purchasing&query.queryName=paymentOptions">Payment Options</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/admin-customizeEmail.view?">Email Templates</a></span></div>

--- a/WNPRC_Purchasing/resources/views/purchasingLanding.html
+++ b/WNPRC_Purchasing/resources/views/purchasingLanding.html
@@ -1,21 +1,5 @@
-<script type="text/javascript">
-
-    function goToRequestersPage() {
-        window.location = LABKEY.ActionURL.buildURL('WNPRC_Purchasing', 'requester', LABKEY.ActionURL.getContainer());
-    }
-
-    function goToPurchaseAdminPage() {
-        window.location = LABKEY.ActionURL.buildURL('WNPRC_Purchasing', 'purchaseAdmin', LABKEY.ActionURL.getContainer());
-    }
-
-    function goToPurchaseReceiverPage() {
-        window.location = LABKEY.ActionURL.buildURL('WNPRC_Purchasing', 'purchaseReceiver', LABKEY.ActionURL.getContainer());
-    }
-
-</script>
-
 <div id="<%=h('wnprc_purchasing-admin-page')%>"></div>
 <h4 style="font-family: Roboto;font-size: 14px;font-weight: bold;">WNPRC Purchasing Portal</h4>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToRequestersPage()">Purchasing Requests</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToPurchaseAdminPage()">Purchasing Admin</a></span></div>
-<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="javascript:goToPurchaseReceiverPage()">Purchasing Receiver</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/WNPRC_Purchasing-requester.view?">Purchasing Requests</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/WNPRC_Purchasing-purchaseAdmin.view?">Purchasing Admin</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/WNPRC_Purchasing-purchaseReceiver.view?">Purchasing Receiver</a></span></div>

--- a/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
+++ b/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
@@ -417,9 +417,9 @@ export const App: FC = memo(() => {
                             onInputChange={requestOrderModelChange}
                             model={requestOrderModel}
                             hasRequestId={!!requestId}
+                            isRequester={hasPurchasingInsertPermission && !hasPurchasingAdminPermission && !hasPurchasingUpdatePermission}
                             isAdmin={hasPurchasingAdminPermission}
-                            canUpdate={hasPurchasingUpdatePermission}
-                            canInsert={hasPurchasingInsertPermission}
+                            isReceiver={hasPurchasingUpdatePermission && !hasPurchasingAdminPermission}
                         />
                         {requestId && hasPurchasingAdminPermission && (
                             <PurchaseAdminPanel onInputChange={purchaseAdminModelChange} model={purchaseAdminModel} />
@@ -433,9 +433,9 @@ export const App: FC = memo(() => {
                             lineItems={lineItems}
                             errorMsg={lineItemErrorMsg}
                             hasRequestId={!!requestId}
+                            isRequester={hasPurchasingInsertPermission && !hasPurchasingAdminPermission && !hasPurchasingUpdatePermission}
                             isAdmin={hasPurchasingAdminPermission}
-                            canUpdate={hasPurchasingUpdatePermission}
-                            canInsert={hasPurchasingInsertPermission}
+                            isReceiver={hasPurchasingUpdatePermission && !hasPurchasingAdminPermission}
                         />
                         <button
                             disabled={isSaving}

--- a/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
+++ b/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
@@ -449,7 +449,7 @@ export const App: FC = memo(() => {
                         {!isSaving && (
                             <>
                                 <button
-                                    disabled={requestId && hasPurchasingInsertPermission && !hasPurchasingAdminPermission}
+                                    disabled={requestId && !hasPurchasingUpdatePermission}
                                     className="btn btn-primary pull-right"
                                     id={requestId ? 'save' : 'submitForReview'}
                                     name={requestId ? 'save' : 'submitForReview'}

--- a/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
+++ b/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
@@ -249,7 +249,8 @@ export const App: FC = memo(() => {
                 documentAttachmentModel.filesToUpload?.size > 0 || documentAttachmentModel.savedFiles?.length > 0
                     ? documentAttachmentModel
                     : undefined,
-                lineItemRowsToDelete
+                lineItemRowsToDelete,
+                ActionURL.getParameter('isNewRequest')
             )
                 .then(r => {
                     if (r.success) {

--- a/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
+++ b/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
@@ -48,6 +48,7 @@ export const App: FC = memo(() => {
     const [isDirty, setIsDirty] = useState<boolean>(false);
     const [isSaving, setIsSaving] = useState<boolean>(false);
     const [requestId, setRequestId] = useState<string>();
+    const [requester, setRequester] = useState<number>();
     const { isAdmin: hasPurchasingAdminPermission, canUpdate: hasPurchasingUpdatePermission, canInsert: hasPurchasingInsertPermission } = getServerContext().user;
 
     // equivalent to componentDidMount and componentDidUpdate (if with dependencies, then equivalent to componentDidUpdate)
@@ -107,6 +108,7 @@ export const App: FC = memo(() => {
                                 cardPostDate: vals[0].cardPostDate ? new Date(vals[0].cardPostDate) : null,
                             })
                         );
+                        setRequester(vals[0].createdBy);
                     }
                 });
 
@@ -403,21 +405,21 @@ export const App: FC = memo(() => {
 
     return (
         <>
-            {
-                // has to be a purchasing editors to update the existing request
-                requestId && !hasPurchasingUpdatePermission && (
+            { (requestId && (!hasPurchasingUpdatePermission && hasPurchasingInsertPermission && !hasPurchasingAdminPermission && getServerContext().user.id !== requester)) && (
                     <Alert>You do not have sufficient permissions to update this request.</Alert>
                 )
             }
             {
-                // display ui for purchasing editors to update existing request or requesters to enter new request
-                ((requestId && hasPurchasingUpdatePermission) || requestId === undefined) && (
+                // display ui for purchasing editors to update existing request or requesters to enter new request or requesters to see a read only view of the existing request
+                ((requestId && hasPurchasingUpdatePermission) || requestId === undefined || (requestId && hasPurchasingInsertPermission && getServerContext().user.id === requester)) && (
                     <>
                         <RequestOrderPanel
                             onInputChange={requestOrderModelChange}
                             model={requestOrderModel}
+                            hasRequestId={!!requestId}
                             isAdmin={hasPurchasingAdminPermission}
                             canUpdate={hasPurchasingUpdatePermission}
+                            canInsert={hasPurchasingInsertPermission}
                         />
                         {requestId && hasPurchasingAdminPermission && (
                             <PurchaseAdminPanel onInputChange={purchaseAdminModelChange} model={purchaseAdminModel} />
@@ -447,6 +449,7 @@ export const App: FC = memo(() => {
                         {!isSaving && (
                             <>
                                 <button
+                                    disabled={requestId && hasPurchasingInsertPermission && !hasPurchasingAdminPermission}
                                     className="btn btn-primary pull-right"
                                     id={requestId ? 'save' : 'submitForReview'}
                                     name={requestId ? 'save' : 'submitForReview'}

--- a/WNPRC_Purchasing/src/client/actions.ts
+++ b/WNPRC_Purchasing/src/client/actions.ts
@@ -77,13 +77,15 @@ export async function submitRequest(
     qcStates: QCStateModel[],
     purchasingAdminModel?: PurchaseAdminModel,
     documentAttachmentModel?: DocumentAttachmentModel,
-    lineItemsToDelete?: number[]
+    lineItemsToDelete?: number[],
+    isNewRequest?: boolean
 ): Promise<any> {
     return new Promise<any>((resolve, reject) => {
         return Ajax.request({
             url: ActionURL.buildURL('WNPRC_Purchasing', 'submitRequest.api'),
             method: 'POST',
             jsonData: {
+                isNewRequest: isNewRequest,
                 rowId: requestOrder.rowId,
                 account: requestOrder.account !== 'Other' ? requestOrder.account : -1,
                 accountOther: requestOrder.otherAcctAndInves,

--- a/WNPRC_Purchasing/src/client/actions.ts
+++ b/WNPRC_Purchasing/src/client/actions.ts
@@ -47,8 +47,9 @@ function getQCState(purchasingAdminModel: PurchaseAdminModel, requestOrder: Requ
         return qcState.label === 'Order Complete';
     });
 
-    // if 'order complete' state is set, return
-    if (completeState?.[0]?.rowId === qcState) {
+    // if 'order complete' state is set, return.
+    // Note: using double equals instead of triple to perform type coercion, qcState value is with "", and rowId value is without.
+    if (completeState?.[0]?.rowId == qcState) {
         return qcState;
     }
 

--- a/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
@@ -59,21 +59,21 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                             value={model.item}
                             hasError={model.errors?.find(field => field.fieldName === 'item')}
                             onChange={onValueChange}
-                            isReadOnly={!isAdmin && canUpdate}
+                            isReadOnly={(!isAdmin && canUpdate) || (hasRequestId && canInsert && !isAdmin)}
                         />
                     </Col>
                     <Col xs={1}>
                         <ControlledSubstance
                             value={model.controlledSubstance}
                             onChange={onValueChange}
-                            isReadOnly={!isAdmin && canUpdate}/>
+                            isReadOnly={(!isAdmin && canUpdate) || (hasRequestId && canInsert && !isAdmin)}/>
                     </Col>
                     <Col xs={1}>
                         <UnitInput
                             value={model.itemUnit}
                             hasError={model.errors?.find(field => field.fieldName === 'itemUnit')}
                             onChange={onValueChange}
-                            isReadOnly={!isAdmin && canUpdate}
+                            isReadOnly={(!isAdmin && canUpdate) || (hasRequestId && canInsert && !isAdmin)}
                         />
                     </Col>
                     { (isAdmin || !canUpdate) &&
@@ -82,6 +82,7 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                                     value={model.unitCost}
                                     hasError={model.errors?.find(field => field.fieldName === 'unitCost')}
                                     onChange={onValueChange}
+                                    isReadOnly={hasRequestId && canInsert && !isAdmin}
                             />
                         </Col>
                     }
@@ -90,15 +91,16 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                             value={model.quantity}
                             hasError={model.errors?.find(field => field.fieldName === 'quantity')}
                             onChange={onValueChange}
-                            isReadOnly={!isAdmin && canUpdate}
+                            isReadOnly={(!isAdmin && canUpdate) || (hasRequestId && canInsert && !isAdmin)}
                         />
                     </Col>
-                    { hasRequestId && (isAdmin || canUpdate) &&
+                    { hasRequestId && ((isAdmin || canUpdate) || (canInsert && !isAdmin)) &&
                     <Col xs={1}>
                         <QuantityReceivedInput
                                 value={model.quantityReceived}
                                 hasError={model.errors?.find(field => field.fieldName === 'quantityReceived')}
                                 onChange={onValueChange}
+                                isReadOnly={hasRequestId && !canUpdate && canInsert && !isAdmin}
                         />
                     </Col>
                     }
@@ -113,7 +115,7 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                     { !hasRequestId &&
                         <Col xs={2}/>
                     }
-                    {(isAdmin || !canUpdate) &&
+                    {(isAdmin || (!hasRequestId && canInsert && !isAdmin)) &&
                         <Col xs={1}>
                                 <span
                                         id={'delete-line-item-row-' + rowIndex}

--- a/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
@@ -22,13 +22,13 @@ interface LineItemProps {
     onDelete: (rowIndex: number) => void;
     rowIndex: number;
     isAdmin: boolean;
-    canUpdate: boolean;
-    canInsert: boolean;
+    isRequester: boolean;
+    isReceiver: boolean;
     hasRequestId?: boolean;
 }
 
 export const LineItemRow: FC<LineItemProps> = memo(props => {
-    const { model, onInputChange, onDelete, rowIndex, isAdmin, canUpdate, canInsert, hasRequestId } = props;
+    const { model, onInputChange, onDelete, rowIndex, isAdmin, isRequester, isReceiver, hasRequestId } = props;
 
     const onValueChange = useCallback(
         (colName, value) => {
@@ -59,30 +59,31 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                             value={model.item}
                             hasError={model.errors?.find(field => field.fieldName === 'item')}
                             onChange={onValueChange}
-                            isReadOnly={(!isAdmin && canUpdate) || (hasRequestId && canInsert && !isAdmin)}
+                            isReadOnly={hasRequestId && (isRequester || isReceiver)}
                         />
                     </Col>
                     <Col xs={1}>
                         <ControlledSubstance
                             value={model.controlledSubstance}
                             onChange={onValueChange}
-                            isReadOnly={(!isAdmin && canUpdate) || (hasRequestId && canInsert && !isAdmin)}/>
+                            isReadOnly={hasRequestId && (isRequester || isReceiver)}
+                        />
                     </Col>
                     <Col xs={1}>
                         <UnitInput
                             value={model.itemUnit}
                             hasError={model.errors?.find(field => field.fieldName === 'itemUnit')}
                             onChange={onValueChange}
-                            isReadOnly={(!isAdmin && canUpdate) || (hasRequestId && canInsert && !isAdmin)}
+                            isReadOnly={hasRequestId && (isRequester || isReceiver)}
                         />
                     </Col>
-                    { (isAdmin || !canUpdate) &&
+                    { (isAdmin || isRequester) &&
                         <Col xs={1}>
                             <UnitCostInput
                                     value={model.unitCost}
                                     hasError={model.errors?.find(field => field.fieldName === 'unitCost')}
                                     onChange={onValueChange}
-                                    isReadOnly={hasRequestId && canInsert && !isAdmin}
+                                    isReadOnly={hasRequestId && isRequester}
                             />
                         </Col>
                     }
@@ -91,20 +92,20 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                             value={model.quantity}
                             hasError={model.errors?.find(field => field.fieldName === 'quantity')}
                             onChange={onValueChange}
-                            isReadOnly={(!isAdmin && canUpdate) || (hasRequestId && canInsert && !isAdmin)}
+                            isReadOnly={hasRequestId && (isRequester || isReceiver)}
                         />
                     </Col>
-                    { hasRequestId && ((isAdmin || canUpdate) || (canInsert && !isAdmin)) &&
+                    { (hasRequestId) &&
                     <Col xs={1}>
                         <QuantityReceivedInput
                                 value={model.quantityReceived}
                                 hasError={model.errors?.find(field => field.fieldName === 'quantityReceived')}
                                 onChange={onValueChange}
-                                isReadOnly={hasRequestId && !canUpdate && canInsert && !isAdmin}
+                                isReadOnly={hasRequestId && isRequester}
                         />
                     </Col>
                     }
-                    { (isAdmin || !canUpdate) &&
+                    { (isAdmin || isRequester) &&
                         <Col xs={1}>
                             <SubtotalInput unitCost={model.unitCost} quantity={model.quantity} />
                         </Col>
@@ -115,7 +116,7 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                     { !hasRequestId &&
                         <Col xs={2}/>
                     }
-                    {(isAdmin || (!hasRequestId && canInsert && !isAdmin)) &&
+                    {(isAdmin || (!hasRequestId && isRequester)) &&
                         <Col xs={1}>
                                 <span
                                         id={'delete-line-item-row-' + rowIndex}

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
@@ -16,12 +16,12 @@ interface Props {
     errorMsg?: string;
     hasRequestId?: boolean;
     isAdmin: boolean;
-    canUpdate: boolean;
-    canInsert: boolean;
+    isRequester: boolean;
+    isReceiver: boolean;
 }
 
 export const LineItemsPanel: FC<Props> = memo(props => {
-    const { lineItems, onChange, errorMsg, hasRequestId, isAdmin, canUpdate, canInsert } = props;
+    const { lineItems, onChange, errorMsg, hasRequestId, isAdmin, isRequester, isReceiver } = props;
 
     const lineItemRowChange = useCallback(
         (lineItem, updatedRowIndex) => {
@@ -82,14 +82,14 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                             <Col xs={4}>Part no./Item description *</Col>
                             <Col xs={1}>Controlled substance</Col>
                             <Col xs={1}>Unit *</Col>
-                            { (isAdmin || !canUpdate) &&
+                            { (isAdmin || isRequester) &&
                                 <Col xs={1}>Unit Cost ($) *</Col>
                             }
                             <Col xs={1}>Quantity *</Col>
-                            { (hasRequestId && (isAdmin || canUpdate || (canInsert && !isAdmin))) &&
+                            { (hasRequestId) &&
                                 <Col xs={1}>Quantity received</Col>
                             }
-                            { (isAdmin || !canUpdate) &&
+                            { (isAdmin || isRequester) &&
                                 <Col xs={1}>Subtotal ($)</Col>
                             }
                         </Row>
@@ -104,15 +104,15 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                                 onInputChange={lineItemRowChange}
                                 onDelete={onDeleteRow}
                                 isAdmin={isAdmin}
-                                canUpdate={canUpdate}
-                                canInsert={canInsert}
+                                isRequester={isRequester}
+                                isReceiver={isReceiver}
                                 hasRequestId={hasRequestId}
                             />
                         );
                     })}
                 </div>
                 <div>
-                    { (isAdmin || !canUpdate) && (
+                    { (isAdmin || isRequester) && (
                             <>
                                 <div>
                                     <Row>
@@ -128,7 +128,8 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                                         </Col>
                                     </Row>
                                 </div>
-                                {(isAdmin || (!hasRequestId && canInsert && !isAdmin)) && (
+                                {/* Allow adding line items for Admins or new requests for Requesters */}
+                                {(isAdmin || (!hasRequestId && isRequester)) && (
                                     <>
                                     <div className="add-item">
                                         <span id="add-line-item-row" title="Add item" className="add-item-icon"

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
@@ -86,7 +86,7 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                                 <Col xs={1}>Unit Cost ($) *</Col>
                             }
                             <Col xs={1}>Quantity *</Col>
-                            { hasRequestId && (isAdmin || canUpdate) &&
+                            { (hasRequestId && (isAdmin || canUpdate || (canInsert && !isAdmin))) &&
                                 <Col xs={1}>Quantity received</Col>
                             }
                             { (isAdmin || !canUpdate) &&
@@ -117,7 +117,7 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                                 <div>
                                     <Row>
                                         <Col xs={6}></Col>
-                                        {hasRequestId && (isAdmin || canUpdate) &&
+                                        {hasRequestId &&
                                             <Col xs={1}></Col>
                                         }
                                         <Col xs={1}></Col>
@@ -128,13 +128,17 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                                         </Col>
                                     </Row>
                                 </div>
-                                <div className="add-item">
-                                    <span id="add-line-item-row" title="Add item" className="add-item-icon"
-                                          onClick={onClickAddRow}>
-                                    <FontAwesomeIcon className="fa-faPlusCircle" icon={faPlusCircle} color="green"/> Add item
-                                    </span>
-                                </div>
-                                {errorMsg && <div className="alert alert-danger">{errorMsg}</div>}
+                                {(isAdmin || (!hasRequestId && canInsert && !isAdmin)) && (
+                                    <>
+                                    <div className="add-item">
+                                        <span id="add-line-item-row" title="Add item" className="add-item-icon"
+                                              onClick={onClickAddRow}>
+                                        <FontAwesomeIcon className="fa-faPlusCircle" icon={faPlusCircle} color="green"/> Add item
+                                        </span>
+                                    </div>
+                                    {errorMsg && <div className="alert alert-danger">{errorMsg}</div>}
+                                    </>
+                                )}
                             </>
                         )
                     }

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
@@ -77,7 +77,7 @@ interface NumericInputProps {
 }
 
 export const UnitCostInput: FC<NumericInputProps> = memo(props => {
-    const { onChange, value, hasError } = props;
+    const { onChange, value, hasError, isReadOnly } = props;
 
     const onValueChange = useCallback(
         evt => {
@@ -94,6 +94,7 @@ export const UnitCostInput: FC<NumericInputProps> = memo(props => {
             id="unit-cost-id"
             pattern="[0-9]*"
             type="number"
+            disabled={isReadOnly}
         />
     );
 });
@@ -122,7 +123,7 @@ export const UnitQuantityInput: FC<NumericInputProps> = memo(props => {
 });
 
 export const QuantityReceivedInput: FC<NumericInputProps> = memo(props => {
-    const { onChange, value, hasError } = props;
+    const { onChange, value, hasError, isReadOnly } = props;
 
     const onValueChange = useCallback(
         evt => {
@@ -139,6 +140,7 @@ export const QuantityReceivedInput: FC<NumericInputProps> = memo(props => {
             pattern="[0-9]*"
             id="quantity-received-id"
             type="number"
+            disabled={isReadOnly}
         />
     );
 });

--- a/WNPRC_Purchasing/src/client/components/RequestOrderPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/RequestOrderPanel.tsx
@@ -20,10 +20,12 @@ interface Props {
     onInputChange: (model: RequestOrderModel) => void;
     isAdmin: boolean;
     canUpdate: boolean;
+    canInsert: boolean;
+    hasRequestId?: boolean;
 }
 
 export const RequestOrderPanel: FC<Props> = memo(props => {
-    const { model, onInputChange, isAdmin, canUpdate } = props;
+    const { model, onInputChange, isAdmin, canUpdate, canInsert, hasRequestId } = props;
 
     const [showOtherAcct, setShowOtherAcct] = useState<boolean>(false);
 
@@ -63,7 +65,7 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
 
     return (
         <>
-        { !isAdmin && canUpdate && (
+        { ((!isAdmin && canUpdate) || (hasRequestId && !canUpdate && !isAdmin)) && (
                 <Panel
                     className="panel panel-default"
                     expanded={true}
@@ -76,15 +78,29 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
                     </div>
                     <Form className="form-margin">
                         <Row>
+                            { (hasRequestId && !canUpdate && !isAdmin) && (
+                                <Col xs={11} lg={6}>
+                                    <AccountInput
+                                        value={model.account}
+                                        isReadOnly={true}
+                                    />
+                                    {(showOtherAcct || model.account === 'Other') && (
+                                        <AccountOtherInput
+                                            value={model.otherAcctAndInves}
+                                            isReadOnly={true}
+                                        />
+                                    )}
+                                </Col>
+                            )}
                             <Col xs={11} lg={6}>
-                                <VendorInput
-                                    model={model}
+                                <ShippingDestinationInput
+                                    value={model.shippingInfoId}
                                     isReadOnly={true}
                                 />
                             </Col>
                             <Col xs={11} lg={6}>
-                                <ShippingDestinationInput
-                                    value={model.shippingInfoId}
+                                <VendorInput
+                                    model={model}
                                     isReadOnly={true}
                                 />
                             </Col>
@@ -94,6 +110,14 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
                                     isReadOnly={true}
                                 />
                             </Col>
+                            { (hasRequestId && !canUpdate && !isAdmin) && (
+                                <Col xs={11} lg={6}>
+                                    <BusinessPurposeInput
+                                        value={model.justification}
+                                        isReadOnly={true}
+                                    />
+                                </Col>
+                            )}
                             <Col xs={11} lg={6}>
                                 <SpecialInstructionInput
                                     value={model.comments}
@@ -105,7 +129,7 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
                 </Panel>
             )
         }
-        { (isAdmin || !canUpdate) && (
+        { (isAdmin || (!hasRequestId && canInsert && !isAdmin)) && (
                 <Panel
                     className="panel panel-default"
                     expanded={true}

--- a/WNPRC_Purchasing/src/client/components/RequestOrderPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/RequestOrderPanel.tsx
@@ -19,13 +19,13 @@ interface Props {
     model: RequestOrderModel;
     onInputChange: (model: RequestOrderModel) => void;
     isAdmin: boolean;
-    canUpdate: boolean;
-    canInsert: boolean;
+    isRequester: boolean;
+    isReceiver: boolean;
     hasRequestId?: boolean;
 }
 
 export const RequestOrderPanel: FC<Props> = memo(props => {
-    const { model, onInputChange, isAdmin, canUpdate, canInsert, hasRequestId } = props;
+    const { model, onInputChange, isAdmin, isRequester, isReceiver, hasRequestId } = props;
 
     const [showOtherAcct, setShowOtherAcct] = useState<boolean>(false);
 
@@ -65,7 +65,8 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
 
     return (
         <>
-        { ((!isAdmin && canUpdate) || (hasRequestId && !canUpdate && !isAdmin)) && (
+        {/* Read only - for the Requesters and Receivers */}
+        { (hasRequestId && (isReceiver || isRequester)) && (
                 <Panel
                     className="panel panel-default"
                     expanded={true}
@@ -78,7 +79,7 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
                     </div>
                     <Form className="form-margin">
                         <Row>
-                            { (hasRequestId && !canUpdate && !isAdmin) && (
+                            { isRequester && (
                                 <Col xs={11} lg={6}>
                                     <AccountInput
                                         value={model.account}
@@ -110,7 +111,7 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
                                     isReadOnly={true}
                                 />
                             </Col>
-                            { (hasRequestId && !canUpdate && !isAdmin) && (
+                            { isRequester && (
                                 <Col xs={11} lg={6}>
                                     <BusinessPurposeInput
                                         value={model.justification}
@@ -129,7 +130,9 @@ export const RequestOrderPanel: FC<Props> = memo(props => {
                 </Panel>
             )
         }
-        { (isAdmin || (!hasRequestId && canInsert && !isAdmin)) && (
+
+        {/* For the Admins for new and old requests; and for the Requesters for new requests */}
+        { (isAdmin || (!hasRequestId && isRequester)) && (
                 <Panel
                     className="panel panel-default"
                     expanded={true}

--- a/WNPRC_Purchasing/src/client/components/RequestOrderPanelInputs.tsx
+++ b/WNPRC_Purchasing/src/client/components/RequestOrderPanelInputs.tsx
@@ -21,7 +21,7 @@ interface InputProps {
 }
 
 export const AccountInput: FC<InputProps> = memo(props => {
-    const { onChange, value, hasError } = props;
+    const { onChange, value, hasError, isReadOnly } = props;
     const [dropDownVals, setDropDownVals] = useState<any[]>();
 
     useEffect(() => {
@@ -47,6 +47,7 @@ export const AccountInput: FC<InputProps> = memo(props => {
                     value={value}
                     onChange={onValueChange}
                     placeholder="Please provide the purpose for this purchasing request (Required)"
+                    disabled={isReadOnly}
                 >
                     <option hidden value="">
                         Select
@@ -59,7 +60,7 @@ export const AccountInput: FC<InputProps> = memo(props => {
 });
 
 export const AccountOtherInput: FC<InputProps> = memo(props => {
-    const { onChange, value, hasError, hasOtherAcctWarning } = props;
+    const { onChange, value, hasError, hasOtherAcctWarning, isReadOnly } = props;
 
     const onTextChange = useCallback(
         evt => {
@@ -80,7 +81,8 @@ export const AccountOtherInput: FC<InputProps> = memo(props => {
                     onChange={onTextChange}
                     id="account-and-pi-id"
                     placeholder="You selected 'Other' for 'Account to charge', please provide an account and principal investigator (Required)"
-                ></textarea>
+                    readOnly={isReadOnly}
+                />
             </PurchasingFormInput>
         </div>
     );
@@ -195,7 +197,7 @@ export const VendorInput: FC<VendorInputProps> = memo(props => {
 });
 
 export const BusinessPurposeInput: FC<InputProps> = memo(props => {
-    const { onChange, value, hasError } = props;
+    const { onChange, value, hasError, isReadOnly } = props;
 
     const onTextChange = useCallback(
         evt => {
@@ -213,6 +215,7 @@ export const BusinessPurposeInput: FC<InputProps> = memo(props => {
                     onChange={onTextChange}
                     id="business-purpose-id"
                     placeholder="Please provide the purpose for this purchasing request (Required)"
+                    readOnly={isReadOnly}
                 />
             </PurchasingFormInput>
         </div>

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
@@ -1,0 +1,177 @@
+package org.labkey.wnprc_purchasing;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.util.emailTemplate.EmailTemplate;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LineItemChangeEmailTemplate extends EmailTemplate
+{
+    protected static final String DEFAULT_SUBJECT = "Purchase request no. ^requestNum^ has updated line items";
+    protected static final String DEFAULT_DESCRIPTION = "Line item update notification";
+    protected static final String NAME = "WNPRC Purchasing - Line item update notification";
+
+    private final List<ReplacementParam> _replacements = new ArrayList<>();
+    private WNPRC_PurchasingController.EmailTemplateForm _notificationBean;
+
+    private List<WNPRC_PurchasingController.LineItem> _updatedLineItemsList;
+    private List<WNPRC_PurchasingController.LineItem> _oldLineItemsList;
+
+
+    public LineItemChangeEmailTemplate()
+    {
+        super(NAME, DEFAULT_SUBJECT, loadBody(), DEFAULT_DESCRIPTION, ContentType.HTML);
+        setEditableScopes(Scope.SiteOrFolder);
+
+        _replacements.add(new ReplacementParam<Integer>("requestNum", Integer.class, "Request number")
+        {
+            @Override
+            public Integer getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getRowId();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("vendor", String.class, "Vendor name")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getVendor();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("status", String.class, "Request status")
+        {
+            @Override
+            public String getValue(Container c)
+            {
+                if (_notificationBean == null)
+                    return null;
+                if (_notificationBean.getRequestStatus().equalsIgnoreCase("order placed"))
+                    return "ordered";
+                return _notificationBean.getRequestStatus();
+            }
+        });
+
+        _replacements.add(new ReplacementParam<String>("created", String.class, "Date of request submission")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getRequestDate();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("total", String.class, "Total cost")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getFormattedTotalCost();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("updatedLineItems", String.class, "Modified or newly added or removed line items", ContentType.HTML)
+        {
+            @Override
+            public String getValue(Container c)
+            {
+                if (getUpdatedLineItemsList() != null)
+                {
+                    HtmlStringBuilder builder = HtmlStringBuilder.of();
+
+                    builder.append(HtmlString.unsafe("<table>"));
+                    for (WNPRC_PurchasingController.LineItem _item : getUpdatedLineItemsList())
+                    {
+                        builder.append(getHtmlString(_item, builder));
+                    }
+                    builder.append(HtmlString.unsafe("</table>"));
+
+                    return builder.getHtmlString().toString();
+                }
+                return null;
+            }
+        });
+
+        _replacements.add(new ReplacementParam<String>("oldLineItems", String.class, "Previously saved line items", ContentType.HTML)
+        {
+            @Override
+            public String getValue(Container c)
+            {
+                if (getOldLineItemsList() != null)
+                {
+                    HtmlStringBuilder builder = HtmlStringBuilder.of();
+
+                    builder.append(HtmlString.unsafe("<table>"));
+                    for (WNPRC_PurchasingController.LineItem _item : getOldLineItemsList())
+                    {
+                        builder.append(getHtmlString(_item, builder));
+                    }
+                    builder.append(HtmlString.unsafe("</table>"));
+
+                    return builder.getHtmlString().toString();
+                }
+                return null;
+            }
+        });
+
+        _replacements.addAll(super.getValidReplacements());
+    }
+
+    private static String loadBody()
+    {
+        try
+        {
+            try (InputStream is = ModuleLoader.getInstance().getModule("WNPRC_Purchasing").getModuleResource("lineItemsChange.txt").getInputStream())
+            {
+                return PageFlowUtil.getStreamContentsAsString(is);
+            }
+        }
+        catch (IOException e)
+        {
+            throw UnexpectedException.wrap(e);
+        }
+    }
+
+    public void setNotificationBean(WNPRC_PurchasingController.EmailTemplateForm notificationBean)
+    {
+        _notificationBean = notificationBean;
+    }
+
+    public List<WNPRC_PurchasingController.LineItem> getOldLineItemsList()
+    {
+        return _oldLineItemsList;
+    }
+
+    public void setOldLineItemsList(List<WNPRC_PurchasingController.LineItem> oldLineItemsList)
+    {
+        _oldLineItemsList = oldLineItemsList;
+    }
+
+    public List<WNPRC_PurchasingController.LineItem> getUpdatedLineItemsList()
+    {
+        return _updatedLineItemsList;
+    }
+
+    public void setUpdatedLineItemsList(List<WNPRC_PurchasingController.LineItem> updatedLineItemsList)
+    {
+        _updatedLineItemsList = updatedLineItemsList;
+    }
+
+    private HtmlString getHtmlString(WNPRC_PurchasingController.LineItem item, HtmlStringBuilder builder)
+    {
+        builder.append(HtmlString.unsafe("<tr>"));
+        builder.append(HtmlString.unsafe("<td>")).append(item.getRowId()).append(HtmlString.unsafe("</td>"));
+        builder.append(HtmlString.unsafe("<td>")).append(item.getItem()).append(HtmlString.unsafe("</td>"));
+        builder.append(HtmlString.unsafe("<td>")).append(String.valueOf(item.getUnitCost())).append(HtmlString.unsafe("</td>"));
+        builder.append(HtmlString.unsafe("<td>")).append(String.valueOf(item.getQuantity())).append(HtmlString.unsafe("</td>"));
+        builder.append(HtmlString.unsafe("<td>")).append(String.valueOf(item.getQuantityReceived())).append(HtmlString.unsafe("</td>"));
+        builder.append(HtmlString.unsafe("</tr>"));
+
+        return builder.getHtmlString();
+    }
+
+    @Override
+    public List<ReplacementParam> getValidReplacements()
+    {
+        return _replacements;
+    }
+
+}

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
@@ -23,7 +23,8 @@ public class LineItemChangeEmailTemplate extends EmailTemplate
 
     private List<WNPRC_PurchasingController.LineItem> _updatedLineItemsList;
     private List<WNPRC_PurchasingController.LineItem> _oldLineItemsList;
-
+    private boolean _hasDeletedLineItems = false;
+    private boolean _hasFullQuantityReceived = false;
 
     public LineItemChangeEmailTemplate()
     {
@@ -65,6 +66,28 @@ public class LineItemChangeEmailTemplate extends EmailTemplate
         {
             @Override
             public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getFormattedTotalCost();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("hasDeletedLineItems", String.class, "For deleted line items", ContentType.Plain)
+        {
+            @Override
+            public String getValue(Container c)
+            {
+                if (_notificationBean != null && _hasDeletedLineItems)
+                    return "Note: There are deleted line items.";
+                return null;
+            }
+        });
+
+        _replacements.add(new ReplacementParam<String>("hasFullQuantityReceived", String.class, "For change in quantity received", ContentType.Plain)
+        {
+            @Override
+            public String getValue(Container c)
+            {
+                if (_notificationBean != null && _hasFullQuantityReceived)
+                    return "All line items are received.";
+                return null;
+            }
         });
 
         _replacements.add(new ReplacementParam<String>("requestDataEntryUrl", String.class, "Request entry url", ContentType.HTML)
@@ -186,4 +209,13 @@ public class LineItemChangeEmailTemplate extends EmailTemplate
         return _replacements;
     }
 
+    public void setDeletedLineItemFlag(boolean isDeleted)
+    {
+        _hasDeletedLineItems = isDeleted;
+    }
+
+    public void setFullQuantityReceivedFlag(boolean quantityReceived)
+    {
+        _hasFullQuantityReceived = quantityReceived;
+    }
 }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class LineItemChangeEmailTemplate extends EmailTemplate
 {
-    protected static final String DEFAULT_SUBJECT = "Purchase request no. ^requestNum^ has updated line items";
+    protected static final String DEFAULT_SUBJECT = "Purchase request # ^requestNum^ has updated line items";
     protected static final String DEFAULT_DESCRIPTION = "Line item update notification";
     protected static final String NAME = "WNPRC Purchasing - Line item update notification";
 

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
@@ -97,10 +97,10 @@ public class LineItemChangeEmailTemplate extends EmailTemplate
             {
                 if (_notificationBean != null)
                 {
-                    ActionURL linkUrl = new ActionURL(WNPRC_PurchasingController.PurchasingRequestAction.class, getContainer());
+                    ActionURL linkUrl = new ActionURL(WNPRC_PurchasingController.PurchasingRequestAction.class, c);
                     linkUrl.addParameter("requestRowId", _notificationBean.getRowId());
                     linkUrl.addParameter("returnUrl", new ActionURL(WNPRC_PurchasingController.RequesterAction.class, c).getPath());
-                    return linkUrl.getBaseServerURI() + c.getPath() + linkUrl.toString();
+                    return linkUrl.getURIString();
                 }
                 return null;
             }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
@@ -100,7 +100,7 @@ public class LineItemChangeEmailTemplate extends EmailTemplate
                     ActionURL linkUrl = new ActionURL(WNPRC_PurchasingController.PurchasingRequestAction.class, getContainer());
                     linkUrl.addParameter("requestRowId", _notificationBean.getRowId());
                     linkUrl.addParameter("returnUrl", new ActionURL(WNPRC_PurchasingController.RequesterAction.class, c).getPath());
-                    return linkUrl.getURIString();
+                    return linkUrl.getBaseServerURI() + c.getPath() + linkUrl.toString();
                 }
                 return null;
             }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/LineItemChangeEmailTemplate.java
@@ -100,7 +100,7 @@ public class LineItemChangeEmailTemplate extends EmailTemplate
                     ActionURL linkUrl = new ActionURL(WNPRC_PurchasingController.PurchasingRequestAction.class, getContainer());
                     linkUrl.addParameter("requestRowId", _notificationBean.getRowId());
                     linkUrl.addParameter("returnUrl", new ActionURL(WNPRC_PurchasingController.RequesterAction.class, c).getPath());
-                    return linkUrl.getBaseServerURI() + c.getPath() + linkUrl.toString();
+                    return linkUrl.getURIString();
                 }
                 return null;
             }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
@@ -11,7 +11,7 @@ public class NewRequestEmailTemplate  extends EmailTemplate
     protected static final String DEFAULT_SUBJECT = "A new purchase request for ^total^ is submitted";
     protected static final String DEFAULT_DESCRIPTION = "WNPRC Purchasing - New request notification";
     protected static final String NAME = "WNPRC Purchasing - New request notification ";
-    protected static final String DEFAULT_BODY = "A new purchasing request ^requestNum^ " +
+    protected static final String DEFAULT_BODY = "A new purchasing request# ^requestNum^ " +
             "by ^requester^ was submitted on ^created^ for the total of ^total^.\n";
 
     private final List<ReplacementParam> _replacements = new ArrayList<>();

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
@@ -2,25 +2,22 @@ package org.labkey.wnprc_purchasing;
 
 import org.labkey.api.data.Container;
 import org.labkey.api.util.emailTemplate.EmailTemplate;
-import org.labkey.api.view.ActionURL;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class NewRequestEmailTemplate  extends EmailTemplate
 {
-    protected static final String DEFAULT_SUBJECT = "Purchase request ^requestNum^ of ^totalCost^ submitted";
+    protected static final String DEFAULT_SUBJECT = "A new purchase request for ^total^ is submitted";
     protected static final String DEFAULT_DESCRIPTION = "New request notification";
     protected static final String NAME = "New request notification ";
     protected static final String DEFAULT_BODY = "A new purchasing request ^requestNum^ " +
-            "by ^requester^ was submitted on ^created^ for the total of ^total^.\n"+
-            "Purpose of this request: ^purpose^ \n"+
-            "More info on the request can be found here: ^detailsUrl^\n";
+            "by ^requester^ was submitted on ^created^ for the total of ^total^.\n";
 
     private final List<ReplacementParam> _replacements = new ArrayList<>();
-    private WNPRC_PurchasingController.RequestForm _notificationBean;
+    private WNPRC_PurchasingController.EmailTemplateForm _notificationBean;
 
-    public NewRequestEmailTemplate(WNPRC_PurchasingController.RequestForm notificationBean)
+    public NewRequestEmailTemplate(WNPRC_PurchasingController.EmailTemplateForm notificationBean)
     {
         super(NAME, DEFAULT_SUBJECT, DEFAULT_BODY, DEFAULT_DESCRIPTION);
         setEditableScopes(EmailTemplate.Scope.SiteOrFolder);
@@ -35,45 +32,25 @@ public class NewRequestEmailTemplate  extends EmailTemplate
         _replacements.add(new ReplacementParam<String>("vendor", String.class, "Vendor name")
         {
             @Override
-            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getVendorName();}
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getVendor();}
         });
 
         _replacements.add(new ReplacementParam<String>("requester", String.class, "Requester name")
         {
             @Override
-            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getRequester();}
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getRequesterFriendlyName();}
         });
 
         _replacements.add(new ReplacementParam<String>("created", String.class, "Date of request submission")
         {
             @Override
-            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getCreatedOn();}
-        });
-
-        _replacements.add(new ReplacementParam<String>("purpose", String.class, "Purpose of the request")
-        {
-            @Override
-            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getPurpose();}
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getRequestDate();}
         });
 
         _replacements.add(new ReplacementParam<String>("total", String.class, "Total cost")
         {
             @Override
             public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getFormattedTotalCost();}
-        });
-
-        _replacements.add(new ReplacementParam<String>("detailsUrl", String.class, "Link to request grid view")
-        {
-            @Override
-            public String getValue(Container c)
-            {
-                ActionURL detailsUrl = new ActionURL("query", "executeQuery", c);
-                detailsUrl.addParameter("schemaName", "ehr_purchasing");
-                detailsUrl.addParameter("query.queryName", "purchasingRequestsOverviewForAdmins");
-                detailsUrl.addParameter("query.viewName", "AllOpenRequests");
-                detailsUrl.addParameter("query.requestNum~eq", _notificationBean.getRowId());
-                return _notificationBean == null ? null : detailsUrl.getURIString();
-            }
         });
 
         _replacements.addAll(super.getValidReplacements());

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
@@ -9,19 +9,18 @@ import java.util.List;
 public class NewRequestEmailTemplate  extends EmailTemplate
 {
     protected static final String DEFAULT_SUBJECT = "A new purchase request for ^total^ is submitted";
-    protected static final String DEFAULT_DESCRIPTION = "New request notification";
-    protected static final String NAME = "New request notification ";
+    protected static final String DEFAULT_DESCRIPTION = "WNPRC Purchasing - New request notification";
+    protected static final String NAME = "WNPRC Purchasing - New request notification ";
     protected static final String DEFAULT_BODY = "A new purchasing request ^requestNum^ " +
             "by ^requester^ was submitted on ^created^ for the total of ^total^.\n";
 
     private final List<ReplacementParam> _replacements = new ArrayList<>();
     private WNPRC_PurchasingController.EmailTemplateForm _notificationBean;
 
-    public NewRequestEmailTemplate(WNPRC_PurchasingController.EmailTemplateForm notificationBean)
+    public NewRequestEmailTemplate()
     {
         super(NAME, DEFAULT_SUBJECT, DEFAULT_BODY, DEFAULT_DESCRIPTION);
         setEditableScopes(EmailTemplate.Scope.SiteOrFolder);
-        _notificationBean = notificationBean;
 
         _replacements.add(new ReplacementParam<Integer>("requestNum", Integer.class, "Request number")
         {
@@ -54,6 +53,11 @@ public class NewRequestEmailTemplate  extends EmailTemplate
         });
 
         _replacements.addAll(super.getValidReplacements());
+    }
+
+    public void setNotificationBean(WNPRC_PurchasingController.EmailTemplateForm notificationBean)
+    {
+        _notificationBean = notificationBean;
     }
 
     @Override

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
@@ -1,0 +1,91 @@
+package org.labkey.wnprc_purchasing;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.util.emailTemplate.EmailTemplate;
+import org.labkey.api.view.ActionURL;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class NewRequestEmailTemplate  extends EmailTemplate
+{
+    protected static final String DEFAULT_SUBJECT = "Purchase request ^requestNum^ of ^totalCost^ submitted";
+    protected static final String DEFAULT_DESCRIPTION = "New request notification";
+    protected static final String NAME = "New request notification ";
+    protected static final String DEFAULT_BODY = "A new purchasing request ^requestNum^ from vendor ^vendor^ " +
+            "by user ^requester^ was submitted on ^created^ for the total of ^total^.\n"+
+            "Purpose of this request: ^purpose^'\n"+
+            "More info on the request can be found here: ^detailsUrl^\n";
+
+    private final List<ReplacementParam> _replacements = new ArrayList<>();
+    private WNPRC_PurchasingController.RequestForm _notificationBean;
+
+    public NewRequestEmailTemplate()
+    {
+        super(NAME, DEFAULT_SUBJECT, DEFAULT_BODY, DEFAULT_DESCRIPTION);
+        setEditableScopes(EmailTemplate.Scope.SiteOrFolder);
+
+        _replacements.add(new ReplacementParam<Integer>("requestNum", Integer.class, "Request number")
+        {
+            @Override
+            public Integer getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getRowId();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("vendor", String.class, "Vendor name")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getVendorName();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("requester", String.class, "Requester name")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getRequester();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("created", String.class, "Date of request submission")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getCreatedOn();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("purpose", String.class, "Purpose of the request")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getPurpose();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("total", String.class, "Total cost")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getFormattedTotalCost();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("detailsUrl", String.class, "Link to request grid view")
+        {
+            @Override
+            public String getValue(Container c)
+            {
+                ActionURL detailsUrl = new ActionURL("query", "executeQuery", c);
+                detailsUrl.addParameter("schemaName", "ehr_purchasing");
+                detailsUrl.addParameter("query.queryName", "purchasingRequestsOverviewForAdmins");
+                detailsUrl.addParameter("query.viewName", "AllOpenRequests");
+                detailsUrl.addParameter("query.requestNum~eq", _notificationBean.getRowId());
+                return _notificationBean == null ? null : detailsUrl.getURIString();
+            }
+        });
+
+        _replacements.addAll(super.getValidReplacements());
+    }
+
+    public WNPRC_PurchasingController.RequestForm getNotificationBean()
+    {
+        return _notificationBean;
+    }
+
+    public void setNotificationBean(WNPRC_PurchasingController.RequestForm notificationBean)
+    {
+        _notificationBean = notificationBean;
+    }
+}

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
@@ -5,7 +5,6 @@ import org.labkey.api.util.emailTemplate.EmailTemplate;
 import org.labkey.api.view.ActionURL;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 public class NewRequestEmailTemplate  extends EmailTemplate
@@ -13,18 +12,19 @@ public class NewRequestEmailTemplate  extends EmailTemplate
     protected static final String DEFAULT_SUBJECT = "Purchase request ^requestNum^ of ^totalCost^ submitted";
     protected static final String DEFAULT_DESCRIPTION = "New request notification";
     protected static final String NAME = "New request notification ";
-    protected static final String DEFAULT_BODY = "A new purchasing request ^requestNum^ from vendor ^vendor^ " +
-            "by user ^requester^ was submitted on ^created^ for the total of ^total^.\n"+
-            "Purpose of this request: ^purpose^'\n"+
+    protected static final String DEFAULT_BODY = "A new purchasing request ^requestNum^ " +
+            "by ^requester^ was submitted on ^created^ for the total of ^total^.\n"+
+            "Purpose of this request: ^purpose^ \n"+
             "More info on the request can be found here: ^detailsUrl^\n";
 
     private final List<ReplacementParam> _replacements = new ArrayList<>();
     private WNPRC_PurchasingController.RequestForm _notificationBean;
 
-    public NewRequestEmailTemplate()
+    public NewRequestEmailTemplate(WNPRC_PurchasingController.RequestForm notificationBean)
     {
         super(NAME, DEFAULT_SUBJECT, DEFAULT_BODY, DEFAULT_DESCRIPTION);
         setEditableScopes(EmailTemplate.Scope.SiteOrFolder);
+        _notificationBean = notificationBean;
 
         _replacements.add(new ReplacementParam<Integer>("requestNum", Integer.class, "Request number")
         {
@@ -79,13 +79,10 @@ public class NewRequestEmailTemplate  extends EmailTemplate
         _replacements.addAll(super.getValidReplacements());
     }
 
-    public WNPRC_PurchasingController.RequestForm getNotificationBean()
+    @Override
+    public List<ReplacementParam> getValidReplacements()
     {
-        return _notificationBean;
+        return _replacements;
     }
 
-    public void setNotificationBean(WNPRC_PurchasingController.RequestForm notificationBean)
-    {
-        _notificationBean = notificationBean;
-    }
 }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/NewRequestEmailTemplate.java
@@ -11,7 +11,7 @@ public class NewRequestEmailTemplate  extends EmailTemplate
     protected static final String DEFAULT_SUBJECT = "A new purchase request for ^total^ is submitted";
     protected static final String DEFAULT_DESCRIPTION = "WNPRC Purchasing - New request notification";
     protected static final String NAME = "WNPRC Purchasing - New request notification ";
-    protected static final String DEFAULT_BODY = "A new purchasing request# ^requestNum^ " +
+    protected static final String DEFAULT_BODY = "A new purchasing request # ^requestNum^ " +
             "by ^requester^ was submitted on ^created^ for the total of ^total^.\n";
 
     private final List<ReplacementParam> _replacements = new ArrayList<>();

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
@@ -3,6 +3,7 @@ package org.labkey.wnprc_purchasing;
 import org.labkey.api.data.Container;
 import org.labkey.api.util.emailTemplate.EmailTemplate;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,8 +12,8 @@ public class RequestStatusChangeEmailTemplate extends EmailTemplate
     protected static final String DEFAULT_SUBJECT = "Purchase request no. ^requestNum^ status update";
     protected static final String DEFAULT_DESCRIPTION = "Request status change notification";
     protected static final String NAME = "WNPRC Purchasing - Request status change notification";
-    protected static final String DEFAULT_BODY = "Your purchase request ^requestNum^ from vendor ^vendor^" +
-            " submitted on ^created^ for the total of ^total^ has been ^status^ by the purchasing department.\n";
+    protected static final String DEFAULT_BODY = "Purchase request no. ^requestNum^ from vendor ^vendor^" +
+            " submitted on ^created^ for the total of ^total^ has been ^status^ by the ^role^.\n";
 
     private final List<ReplacementParam> _replacements = new ArrayList<>();
     private WNPRC_PurchasingController.EmailTemplateForm _notificationBean;
@@ -45,6 +46,8 @@ public class RequestStatusChangeEmailTemplate extends EmailTemplate
                     return "rejected";
                 if (_notificationBean.getRequestStatus().equalsIgnoreCase("Order Placed"))
                     return "ordered";
+                if (_notificationBean.getRequestStatus().equalsIgnoreCase("Request Approved"))
+                    return "approved";
                 return _notificationBean.getRequestStatus();
             }
         });
@@ -65,6 +68,23 @@ public class RequestStatusChangeEmailTemplate extends EmailTemplate
         {
             @Override
             public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getFormattedTotalCost();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("role", String.class, "Purchasing dept or purchasing director")
+        {
+            @Override
+            public String getValue(Container c)
+            {
+                if (_notificationBean != null)
+                {
+                    if (_notificationBean.getTotalCost().compareTo(BigDecimal.valueOf(5000.0)) > 0)
+                    {
+                        return "purchasing director";
+                    }
+                    return "purchasing department";
+                }
+                return _notificationBean == null ? null : _notificationBean.getFormattedTotalCost();
+            }
         });
 
         _replacements.addAll(super.getValidReplacements());

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
@@ -8,21 +8,19 @@ import java.util.List;
 
 public class RequestStatusChangeEmailTemplate extends EmailTemplate
 {
-    protected static final String DEFAULT_SUBJECT = "Purchase request no. ^requestNum^ has been updated";
+    protected static final String DEFAULT_SUBJECT = "Purchase request no. ^requestNum^ status update";
     protected static final String DEFAULT_DESCRIPTION = "Request status change notification";
-    protected static final String NAME = "Request status change notification";
+    protected static final String NAME = "WNPRC Purchasing - Request status change notification";
     protected static final String DEFAULT_BODY = "Your purchase request ^requestNum^ from vendor ^vendor^" +
             " submitted on ^created^ for the total of ^total^ has been ^status^ by the purchasing department.\n";
 
-    protected static final String DEFAULT_BODY_PLUS_ORDER_PLACED = DEFAULT_BODY + " The order was placed on ^orderDate^.";
     private final List<ReplacementParam> _replacements = new ArrayList<>();
     private WNPRC_PurchasingController.EmailTemplateForm _notificationBean;
 
-    public RequestStatusChangeEmailTemplate(WNPRC_PurchasingController.EmailTemplateForm notificationBean)
+    public RequestStatusChangeEmailTemplate()
     {
-        super(NAME, DEFAULT_SUBJECT, (notificationBean.getRequestStatus().equalsIgnoreCase("order placed") ? DEFAULT_BODY_PLUS_ORDER_PLACED : DEFAULT_BODY), DEFAULT_DESCRIPTION);
+        super(NAME, DEFAULT_SUBJECT, DEFAULT_BODY, DEFAULT_DESCRIPTION);
         setEditableScopes(Scope.SiteOrFolder);
-        _notificationBean = notificationBean;
 
         _replacements.add(new ReplacementParam<Integer>("requestNum", Integer.class, "Request number")
         {
@@ -41,6 +39,8 @@ public class RequestStatusChangeEmailTemplate extends EmailTemplate
             @Override
             public String getValue(Container c)
             {
+                if (_notificationBean == null)
+                    return null;
                 if (_notificationBean.getRequestStatus().equalsIgnoreCase("Request Rejected"))
                     return "rejected";
                 if (_notificationBean.getRequestStatus().equalsIgnoreCase("Order Placed"))
@@ -68,6 +68,11 @@ public class RequestStatusChangeEmailTemplate extends EmailTemplate
         });
 
         _replacements.addAll(super.getValidReplacements());
+    }
+
+    public void setNotificationBean(WNPRC_PurchasingController.EmailTemplateForm notificationBean)
+    {
+        _notificationBean = notificationBean;
     }
 
     @Override

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
@@ -9,10 +9,10 @@ import java.util.List;
 
 public class RequestStatusChangeEmailTemplate extends EmailTemplate
 {
-    protected static final String DEFAULT_SUBJECT = "Purchase request no. ^requestNum^ status update";
+    protected static final String DEFAULT_SUBJECT = "Purchase request # ^requestNum^ status update";
     protected static final String DEFAULT_DESCRIPTION = "Request status change notification";
     protected static final String NAME = "WNPRC Purchasing - Request status change notification";
-    protected static final String DEFAULT_BODY = "Purchase request# ^requestNum^ from vendor ^vendor^" +
+    protected static final String DEFAULT_BODY = "Purchase request # ^requestNum^ from vendor ^vendor^" +
             " submitted on ^created^ for the total of ^total^ has been ^status^ by the ^role^.\n";
 
     private final List<ReplacementParam> _replacements = new ArrayList<>();

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
@@ -77,7 +77,7 @@ public class RequestStatusChangeEmailTemplate extends EmailTemplate
             {
                 if (_notificationBean != null)
                 {
-                    if (_notificationBean.getTotalCost().compareTo(BigDecimal.valueOf(WNPRC_PurchasingController.OVER_FIVE_K)) >= 0
+                    if (_notificationBean.getTotalCost().compareTo(BigDecimal.valueOf(WNPRC_PurchasingController.ADDITIONAL_REVIEW_AMT)) >= 0
                             && (_notificationBean.getRequestStatus().equalsIgnoreCase("Request Approved")
                             || _notificationBean.getRequestStatus().equalsIgnoreCase("Request Rejected")))
                     {

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
@@ -77,8 +77,8 @@ public class RequestStatusChangeEmailTemplate extends EmailTemplate
             {
                 if (_notificationBean != null)
                 {
-                    if (_notificationBean.getTotalCost().compareTo(BigDecimal.valueOf(5000.0)) >= 0
-                            & (_notificationBean.getRequestStatus().equalsIgnoreCase("Request Approved")
+                    if (_notificationBean.getTotalCost().compareTo(BigDecimal.valueOf(WNPRC_PurchasingController.OVER_FIVE_K)) >= 0
+                            && (_notificationBean.getRequestStatus().equalsIgnoreCase("Request Approved")
                             || _notificationBean.getRequestStatus().equalsIgnoreCase("Request Rejected")))
                     {
                         return "purchasing director";

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
@@ -12,7 +12,7 @@ public class RequestStatusChangeEmailTemplate extends EmailTemplate
     protected static final String DEFAULT_SUBJECT = "Purchase request no. ^requestNum^ status update";
     protected static final String DEFAULT_DESCRIPTION = "Request status change notification";
     protected static final String NAME = "WNPRC Purchasing - Request status change notification";
-    protected static final String DEFAULT_BODY = "Purchase request no. ^requestNum^ from vendor ^vendor^" +
+    protected static final String DEFAULT_BODY = "Purchase request# ^requestNum^ from vendor ^vendor^" +
             " submitted on ^created^ for the total of ^total^ has been ^status^ by the ^role^.\n";
 
     private final List<ReplacementParam> _replacements = new ArrayList<>();
@@ -77,7 +77,9 @@ public class RequestStatusChangeEmailTemplate extends EmailTemplate
             {
                 if (_notificationBean != null)
                 {
-                    if (_notificationBean.getTotalCost().compareTo(BigDecimal.valueOf(5000.0)) > 0)
+                    if (_notificationBean.getTotalCost().compareTo(BigDecimal.valueOf(5000.0)) >= 0
+                            & (_notificationBean.getRequestStatus().equalsIgnoreCase("Request Approved")
+                            || _notificationBean.getRequestStatus().equalsIgnoreCase("Request Rejected")))
                     {
                         return "purchasing director";
                     }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/RequestStatusChangeEmailTemplate.java
@@ -1,0 +1,79 @@
+package org.labkey.wnprc_purchasing;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.util.emailTemplate.EmailTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RequestStatusChangeEmailTemplate extends EmailTemplate
+{
+    protected static final String DEFAULT_SUBJECT = "Purchase request no. ^requestNum^ has been updated";
+    protected static final String DEFAULT_DESCRIPTION = "Request status change notification";
+    protected static final String NAME = "Request status change notification";
+    protected static final String DEFAULT_BODY = "Your purchase request ^requestNum^ from vendor ^vendor^" +
+            " submitted on ^created^ for the total of ^total^ has been ^status^ by the purchasing department.\n";
+
+    protected static final String DEFAULT_BODY_PLUS_ORDER_PLACED = DEFAULT_BODY + " The order was placed on ^orderDate^.";
+    private final List<ReplacementParam> _replacements = new ArrayList<>();
+    private WNPRC_PurchasingController.EmailTemplateForm _notificationBean;
+
+    public RequestStatusChangeEmailTemplate(WNPRC_PurchasingController.EmailTemplateForm notificationBean)
+    {
+        super(NAME, DEFAULT_SUBJECT, (notificationBean.getRequestStatus().equalsIgnoreCase("order placed") ? DEFAULT_BODY_PLUS_ORDER_PLACED : DEFAULT_BODY), DEFAULT_DESCRIPTION);
+        setEditableScopes(Scope.SiteOrFolder);
+        _notificationBean = notificationBean;
+
+        _replacements.add(new ReplacementParam<Integer>("requestNum", Integer.class, "Request number")
+        {
+            @Override
+            public Integer getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getRowId();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("vendor", String.class, "Vendor name")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getVendor();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("status", String.class, "Request status")
+        {
+            @Override
+            public String getValue(Container c)
+            {
+                if (_notificationBean.getRequestStatus().equalsIgnoreCase("Request Rejected"))
+                    return "rejected";
+                if (_notificationBean.getRequestStatus().equalsIgnoreCase("Order Placed"))
+                    return "ordered";
+                return _notificationBean.getRequestStatus();
+            }
+        });
+
+        _replacements.add(new ReplacementParam<String>("created", String.class, "Date of request submission")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getRequestDate();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("orderDate", String.class, "Order placed date")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getOrderDate();}
+        });
+
+        _replacements.add(new ReplacementParam<String>("total", String.class, "Total cost")
+        {
+            @Override
+            public String getValue(Container c) {return _notificationBean == null ? null : _notificationBean.getFormattedTotalCost();}
+        });
+
+        _replacements.addAll(super.getValidReplacements());
+    }
+
+    @Override
+    public List<ReplacementParam> getValidReplacements()
+    {
+        return _replacements;
+    }
+
+}

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
@@ -53,6 +53,7 @@ import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.MailHelper;
+import org.labkey.api.util.emailTemplate.EmailTemplateService;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.Portal;
@@ -217,7 +218,7 @@ public class WNPRC_PurchasingController extends SpringActionController
                         emailTemplateForm.getRequestStatus().equalsIgnoreCase("Request Approved"))
                )
             {
-                RequestStatusChangeEmailTemplate requestEmailTemplate = new RequestStatusChangeEmailTemplate();
+                RequestStatusChangeEmailTemplate requestEmailTemplate = EmailTemplateService.get().getEmailTemplate(RequestStatusChangeEmailTemplate.class);
                 requestEmailTemplate.setNotificationBean(emailTemplateForm);
                 String emailSubject = requestEmailTemplate.renderSubject(getContainer());
                 String emailBody = requestEmailTemplate.renderBody(getContainer());
@@ -273,7 +274,7 @@ public class WNPRC_PurchasingController extends SpringActionController
 
             if (removed.size() > 0 || quantityChange.size() > 0 || fullQuantityReceived)
             {
-                LineItemChangeEmailTemplate lineItemChangeEmailTemplate = new LineItemChangeEmailTemplate();
+                LineItemChangeEmailTemplate lineItemChangeEmailTemplate = EmailTemplateService.get().getEmailTemplate(LineItemChangeEmailTemplate.class);
                 lineItemChangeEmailTemplate.setUpdatedLineItemsList(incomingLineItems);
                 lineItemChangeEmailTemplate.setOldLineItemsList(oldLineItems);
                 lineItemChangeEmailTemplate.setDeletedLineItemFlag(removed.size() > 0);
@@ -318,7 +319,7 @@ public class WNPRC_PurchasingController extends SpringActionController
 
         private void sendNewRequestEmailNotification(EmailTemplateForm emailTemplateForm) throws MessagingException, IOException, ValidationException
         {
-            NewRequestEmailTemplate requestEmailTemplate = new NewRequestEmailTemplate();
+            NewRequestEmailTemplate requestEmailTemplate = EmailTemplateService.get().getEmailTemplate(NewRequestEmailTemplate.class);
             requestEmailTemplate.setNotificationBean(emailTemplateForm);
             String emailSubject = requestEmailTemplate.renderSubject(getContainer());
             String emailBody = requestEmailTemplate.renderBody(getContainer());

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
@@ -31,6 +31,7 @@ import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.notification.NotificationService;
 import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.Filter;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
@@ -50,6 +51,7 @@ import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.MailHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
@@ -528,7 +530,7 @@ public class WNPRC_PurchasingController extends SpringActionController
         User _requester;
         BigDecimal _totalCost;
 
-        DateFormat _dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        DateFormat _dateFormat = new SimpleDateFormat(DateUtil.getDateFormatString(ContainerManager.getRoot()));
         DecimalFormat _dollarFormat = new DecimalFormat("$#,##0.00");
 
         public Integer getRowId()

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
@@ -18,8 +18,6 @@ package org.labkey.wnprc_purchasing;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -71,7 +69,6 @@ import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
@@ -84,7 +84,7 @@ public class WNPRC_PurchasingController extends SpringActionController
     private static final Logger _log = LogManager.getLogger(WNPRC_PurchasingController.class);
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(WNPRC_PurchasingController.class);
     public static final String NAME = "wnprc_purchasing";
-    public static final Double OVER_FIVE_K = 5000.0;
+    public static final Double ADDITIONAL_REVIEW_AMT = 5000.0; // additional review is required for requests >= $5000
 
     public WNPRC_PurchasingController()
     {
@@ -208,7 +208,7 @@ public class WNPRC_PurchasingController extends SpringActionController
 
             //get the lab end user who originated the request
             List <User> labEndUsers = usersWithInsertPerm.stream().filter(u -> u.getUserId() == emailTemplateForm.getRequester().getUserId()).collect(Collectors.toList());
-            User endUser = labEndUsers.size() == 1 && labEndUsers.get(0) != null ? labEndUsers.get(0) : null;
+            User endUser = labEndUsers.size() == 1 ? labEndUsers.get(0) : null;
 
             //request status change email notification
             if ((StringUtils.isBlank(oldStatus) || !emailTemplateForm.getRequestStatus().equalsIgnoreCase(oldStatus))
@@ -223,7 +223,7 @@ public class WNPRC_PurchasingController extends SpringActionController
                 String emailBody = requestEmailTemplate.renderBody(getContainer());
 
                 //request over 5k is approved or rejected - send notif to purchase admins
-                if (emailTemplateForm.getTotalCost().compareTo(BigDecimal.valueOf(OVER_FIVE_K)) >= 0 &&
+                if (emailTemplateForm.getTotalCost().compareTo(BigDecimal.valueOf(ADDITIONAL_REVIEW_AMT)) >= 0 &&
                         (emailTemplateForm.getRequestStatus().equalsIgnoreCase("Request Rejected") ||
                         emailTemplateForm.getRequestStatus().equalsIgnoreCase("Request Approved")))
                 {
@@ -269,7 +269,7 @@ public class WNPRC_PurchasingController extends SpringActionController
             List<LineItem> quantityChange = incomingLineItems.stream().filter(o1 -> oldLineItems.stream().noneMatch(o2 -> o1.getRowId() == o2.getRowId()
                                                                                     && o2.getQuantity() == o1.getQuantity())).collect(Collectors.toList());
 
-            boolean fullQuantityReceived = incomingLineItems.stream().filter(o2 -> o2.getQuantityReceived() == o2.getQuantity()).count() == incomingLineItems.size();
+            boolean fullQuantityReceived = incomingLineItems.stream().filter(o2 -> o2.getQuantityReceived() >= o2.getQuantity()).count() == incomingLineItems.size();
 
             if (removed.size() > 0 || quantityChange.size() > 0 || fullQuantityReceived)
             {
@@ -323,7 +323,7 @@ public class WNPRC_PurchasingController extends SpringActionController
             String emailSubject = requestEmailTemplate.renderSubject(getContainer());
             String emailBody = requestEmailTemplate.renderBody(getContainer());
 
-            if (emailTemplateForm.getTotalCost().compareTo(BigDecimal.valueOf(OVER_FIVE_K)) >= 0)
+            if (emailTemplateForm.getTotalCost().compareTo(BigDecimal.valueOf(ADDITIONAL_REVIEW_AMT)) >= 0)
             {
                 List<User> adminUsers = SecurityManager.getUsersWithPermissions(getContainer(), Collections.singleton(AdminPermission.class));
 

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingModule.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingModule.java
@@ -26,7 +26,10 @@ import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.QuerySchema;
+import org.labkey.api.security.roles.RoleManager;
+import org.labkey.api.util.emailTemplate.EmailTemplateService;
 import org.labkey.api.view.WebPartFactory;
+import org.labkey.wnprc_purchasing.security.WNPRC_PurchasingDirectorRole;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -65,6 +68,9 @@ public class WNPRC_PurchasingModule extends DefaultModule
     protected void init()
     {
         addController(WNPRC_PurchasingController.NAME, WNPRC_PurchasingController.class);
+        EmailTemplateService.get().registerTemplate(NewRequestEmailTemplate.class);
+
+        RoleManager.registerRole(new WNPRC_PurchasingDirectorRole());
     }
 
     @Override

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingModule.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingModule.java
@@ -69,6 +69,8 @@ public class WNPRC_PurchasingModule extends DefaultModule
     {
         addController(WNPRC_PurchasingController.NAME, WNPRC_PurchasingController.class);
         EmailTemplateService.get().registerTemplate(NewRequestEmailTemplate.class);
+        EmailTemplateService.get().registerTemplate(RequestStatusChangeEmailTemplate.class);
+        EmailTemplateService.get().registerTemplate(LineItemChangeEmailTemplate.class);
         RoleManager.registerRole(new WNPRC_PurchasingDirectorRole());
     }
 

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingModule.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingModule.java
@@ -69,7 +69,6 @@ public class WNPRC_PurchasingModule extends DefaultModule
     {
         addController(WNPRC_PurchasingController.NAME, WNPRC_PurchasingController.class);
         EmailTemplateService.get().registerTemplate(NewRequestEmailTemplate.class);
-
         RoleManager.registerRole(new WNPRC_PurchasingDirectorRole());
     }
 

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/security/WNPRC_PurchasingDirectorRole.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/security/WNPRC_PurchasingDirectorRole.java
@@ -1,0 +1,17 @@
+package org.labkey.wnprc_purchasing.security;
+
+import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.roles.AbstractModuleScopedRole;
+import org.labkey.wnprc_purchasing.WNPRC_PurchasingModule;
+
+public class WNPRC_PurchasingDirectorRole extends AbstractModuleScopedRole
+{
+    public WNPRC_PurchasingDirectorRole()
+    {
+        super("WNPRC Purchasing Director", "This role is used to approve purchase orders that are over $5000.",
+                WNPRC_PurchasingModule.class,
+                AdminPermission.class
+        );
+    }
+}
+

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/security/WNPRC_PurchasingDirectorRole.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/security/WNPRC_PurchasingDirectorRole.java
@@ -6,9 +6,10 @@ import org.labkey.wnprc_purchasing.WNPRC_PurchasingModule;
 
 public class WNPRC_PurchasingDirectorRole extends AbstractModuleScopedRole
 {
+    public static final String PURCHASING_DIRECTOR_ROLE_NAME = "WNPRC Purchasing Director";
     public WNPRC_PurchasingDirectorRole()
     {
-        super("WNPRC Purchasing Director", "This role is used to approve purchase orders that are over $5000.",
+        super(PURCHASING_DIRECTOR_ROLE_NAME, "This role is used to approve purchase orders that are over $5000.",
                 WNPRC_PurchasingModule.class,
                 AdminPermission.class
         );

--- a/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
@@ -78,7 +78,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
     private static final String RECEIVER_USER = "purchasereceiver@test.com";
     private static final String requester1Name = "purchaserequester1";
     private static final String ADMIN_USER = "purchaseadmin@test.com";
-    private static final String PURCHASE_DIRECTOR_USER = "purchaseadirector@test.com";
+    private static final String PURCHASE_DIRECTOR_USER = "purchasedirector@test.com";
     //other properties
 
     //sample data
@@ -190,14 +190,15 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         _permissionsHelper.addUserToProjGroup(_userHelper.getDisplayNameForEmail(PURCHASE_DIRECTOR_USER), getProjectName(), PURCHASE_ADMIN_GROUP);
 
         log("Add users to " + PURCHASE_RECEIVER_GROUP);
-        _permissionsHelper.addUserToProjGroup(RECEIVER_USER, getProjectName(), PURCHASE_ADMIN_GROUP);
+        _permissionsHelper.addUserToProjGroup(RECEIVER_USER, getProjectName(), PURCHASE_RECEIVER_GROUP);
 
         log("Add users to " + PURCHASE_REQUESTER_GROUP);
-        _permissionsHelper.addUserToProjGroup(REQUESTER_USER_1, getProjectName(), PURCHASE_ADMIN_GROUP);
-        _permissionsHelper.addUserToProjGroup(REQUESTER_USER_2, getProjectName(), PURCHASE_ADMIN_GROUP);
+        _permissionsHelper.addUserToProjGroup(REQUESTER_USER_1, getProjectName(), PURCHASE_REQUESTER_GROUP);
+        _permissionsHelper.addUserToProjGroup(REQUESTER_USER_2, getProjectName(), PURCHASE_REQUESTER_GROUP);
 
         _permissionsHelper.setPermissions(PURCHASE_ADMIN_GROUP, "Project Administrator");
         _permissionsHelper.setPermissions(PURCHASE_REQUESTER_GROUP, "Submitter");
+        _permissionsHelper.setPermissions(PURCHASE_REQUESTER_GROUP, "Reader");
         _permissionsHelper.setPermissions(PURCHASE_RECEIVER_GROUP, "Editor");
         _permissionsHelper.setUserPermissions(PURCHASE_DIRECTOR_USER, "WNPRC Purchasing Director");
     }

--- a/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
@@ -186,8 +186,8 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         goToProjectHome();
         log("Add users to " + PURCHASE_ADMIN_GROUP);
         _permissionsHelper.addUserToProjGroup(getCurrentUserName(), getProjectName(), PURCHASE_ADMIN_GROUP);
-        _permissionsHelper.addUserToProjGroup(_userHelper.getDisplayNameForEmail(ADMIN_USER), getProjectName(), PURCHASE_ADMIN_GROUP);
-        _permissionsHelper.addUserToProjGroup(_userHelper.getDisplayNameForEmail(PURCHASE_DIRECTOR_USER), getProjectName(), PURCHASE_ADMIN_GROUP);
+        _permissionsHelper.addUserToProjGroup(ADMIN_USER, getProjectName(), PURCHASE_ADMIN_GROUP);
+        _permissionsHelper.addUserToProjGroup(PURCHASE_DIRECTOR_USER, getProjectName(), PURCHASE_ADMIN_GROUP);
 
         log("Add users to " + PURCHASE_RECEIVER_GROUP);
         _permissionsHelper.addUserToProjGroup(RECEIVER_USER, getProjectName(), PURCHASE_RECEIVER_GROUP);
@@ -348,7 +348,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         checker().verifyEquals("Invalid number of requests ", 1, table.getDataRowCount());
         checker().verifyEquals("Invalid request status ", "Review Pending",
                 table.getDataAsText(0, "requestStatus"));
-        checker().verifyEquals("Invalid Vendor ", "Test1", table.getDataAsText(0, "vendorId"));
+        checker().verifyEquals("Invalid Vendor ", "Test1", table.getDataAsText(0, "vendor"));
         stopImpersonating();
     }
 
@@ -431,8 +431,8 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         stopImpersonating(false);
 
         beginAt(buildRelativeUrl("WNPRC_Purchasing", getProjectName(), "requestEntry", Maps.of("requestRowId", requestID)));
-        log("Impersonate as " + REQUESTER_USER_1);
-        impersonate(REQUESTER_USER_1);
+        log("Impersonate as " + REQUESTER_USER_2);
+        impersonate(REQUESTER_USER_2);
         assertTextPresent("You do not have sufficient permissions to update this request.");
         stopImpersonating();
     }
@@ -514,7 +514,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         DataRegionTable table = new DataRegionTable("query", getDriver());
         checker().verifyEquals("Incorrect request Id's", Arrays.asList(requestId1, requestId2),
                 table.getColumnDataAsText("requestNum"));
-        checker().verifyEquals("Incorrect requester's", Arrays.asList("purchaserequester", "purchaseadmin"),
+        checker().verifyEquals("Incorrect requester's", Arrays.asList("purchaserequester1", "purchaseadmin"),
                 table.getColumnDataAsText("requester"));
 
         log("Changing the assignment of the request");

--- a/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
@@ -34,6 +34,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.EHR;
 import org.labkey.test.categories.WNPRC_EHR;
 import org.labkey.test.componenes.CreateVendorDialog;
+import org.labkey.test.components.dumbster.EmailRecordTable;
 import org.labkey.test.components.html.SiteNavBar;
 import org.labkey.test.util.APIUserHelper;
 import org.labkey.test.util.AbstractUserHelper;
@@ -77,6 +78,8 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
     private static final String REQUESTER_USER_2 = "purchaserequester2@test.com";
     private static final String RECEIVER_USER = "purchasereceiver@test.com";
     private static final String requester1Name = "purchaserequester1";
+    private static final String requester2Name = "purchaserequester2";
+
     private static final String ADMIN_USER = "purchaseadmin@test.com";
     private static final String PURCHASE_DIRECTOR_USER = "purchasedirector@test.com";
     //other properties
@@ -93,6 +96,8 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
     public AbstractUserHelper _userHelper = new APIUserHelper(this);
     ApiPermissionsHelper _apiPermissionsHelper = new ApiPermissionsHelper(this);
     File pdfFile = new File(TestFileUtils.getSampleData("fileTypes"), "pdf_sample.pdf");
+    DateTimeFormatter _dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    LocalDateTime today = LocalDateTime.now();
     private int _adminUserId;
     private int _requesterUserId1;
     private int _requesterUserId2;
@@ -101,7 +106,6 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
     private int _adminGroupId;
     private int _receiverGroupId;
     private int _requesterGroupId;
-
     private SchemaHelper _schemaHelper = new SchemaHelper(this);
     private UIPermissionsHelper _permissionsHelper = new UIPermissionsHelper(this);
 


### PR DESCRIPTION
#### Rationale
Implement email notification upon form submission for a new request submission, request over 5000k, line item changes, request approval or rejection, full quantity received; and send emails to appropriate users.
Spec [here](https://docs.google.com/document/d/1AKhnqOfVJz02K4SR7qY4ohL7jV03gUr-FxAv-dkCIb8/edit#heading=h.ddrj055296t1).

#### Changes
* Create email templates for a new request, line item changes, request status changes.
* Update SubmitRequestAction to send new and updated requests email notification to appropriate users.
* Handle email notif for requests over 5k and less than 5k.
* Handle line item quantity change and full quantity received.
* Handle request status update - mainly Request Rejected, Request Approved, & Order Placed.
* Update data entry form to make it read only for requesters (link in the email will take requesters to this read only data entry page to view the request they submitted).
* Fix issue where Order Complete was not being set correctly.
* Update landing page and admin page url so that they open in a new tab.
* Update default paymentOptions data.
* Update to Receiver's page default view to include the requester.