### PR TITLE
Fix dependency version discrepancies

### DIFF
--- a/GoogleDrive/build.gradle
+++ b/GoogleDrive/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation project(path: "${project.parent.path}:DBUtils",  configuration: "apiJarFile")
     implementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
     implementation files(apiJar)
-    external 'com.google.api-client:google-api-client:1.22.0'
+    external "com.google.api-client:google-api-client:${googleApiClientVersion}"
     external 'com.google.apis:google-api-services-drive:v3-rev85-1.23.0'
     jspImplementation project(BuildUtils.getApiProjectPath(project.gradle))
     jspImplementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")

--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -8,20 +8,23 @@ dependencies {
     implementation project(path: "${project.parent.path}:DBUtils", configuration: "apiJarFile")
     implementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
     implementation project(path: "${project.parent.path}:GoogleDrive", configuration: "apiJarFile")
-    external "joda-time:joda-time:2.8.1"
+    external "joda-time:joda-time:${jodaTimeVersion}"
     external "org.jsoup:jsoup:1.13.1"
     external "org.reflections:reflections:0.9.10"
 
-    external 'com.google.api-client:google-api-client:1.30.5'
-    external 'com.google.apis:google-api-services-calendar:v3-rev20191117-1.30.3'
-    external 'com.google.http-client:google-http-client-gson:1.34.0'
-    external 'com.microsoft.ews-java-api:ews-java-api:2.0'
-    external 'com.google.auth:google-auth-library-oauth2-http:0.19.0'
-    external 'org.apache.commons:commons-text:1.9'
+    external "com.google.api-client:google-api-client:${googleApiClientVersion}"
+    external "com.google.apis:google-api-services-calendar:${googleApiServicesCalendarVersion}"
+    external "com.google.http-client:google-http-client-gson:${googleHttpClientVersion}"
+    external "com.microsoft.ews-java-api:ews-java-api:2.0"
+    external ("com.google.auth:google-auth-library-oauth2-http:0.19.0") {
+        // Avoid conflict with version pulled in by :platform:api and :platform:internal
+        exclude group: "com.google.code.findbugs", module: "jsr305"
+    }
+    external "org.apache.commons:commons-text:1.9"
 
     jspImplementation project(path: "${project.parent.path}:DBUtils",  configuration: "apiJarFile")
     jspImplementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
-    jspImplementation "joda-time:joda-time:2.8.1"
+    jspImplementation "joda-time:joda-time:${jodaTimeVersion}"
 
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')
@@ -37,6 +40,10 @@ dependencies {
 configurations.all {
     Configuration config ->
         resolutionStrategy {
-            force "org.javassist:javassist:3.20.0-GA"
+            force "org.javassist:javassist:${javassistVersion}"
+
+            // Conflicts with versions in 'GoogleDrive' module
+            force "com.google.http-client:google-http-client-jackson2:${googleHttpClientVersion}"
+            force "com.google.http-client:google-http-client:${googleHttpClientVersion}"
         }
 }


### PR DESCRIPTION
#### Rationale
The recent merge from wnprc21.3 introduced several dependency discrepancies.
```
:showDiscrepancies
  com.google.http-client:google-http-client-jackson2 has 2 versions as follows:
    1.33.0  [:server:modules:wnprc-modules:WNPRC_EHR]
    1.23.0  [:server:modules:fileTransfer, :server:modules:harvest, :server:modules:scrumtime, :server:modules:wnprc-modules:GoogleDrive]
  com.google.api-client:google-api-client has 2 versions as follows:
    1.30.5  [:server:modules:wnprc-modules:WNPRC_EHR]
    1.23.0  [:server:modules:harvest, :server:modules:scrumtime, :server:modules:wnprc-modules:GoogleDrive]
  com.google.oauth-client:google-oauth-client has 2 versions as follows:
    1.23.0  [:server:modules:fileTransfer, :server:modules:harvest, :server:modules:scrumtime, :server:modules:wnprc-modules:GoogleDrive]
    1.30.4  [:server:modules:wnprc-modules:WNPRC_EHR]
  com.google.apis:google-api-services-calendar has 2 versions as follows:
    v3-rev255-1.23.0  [:server:modules:harvest]
    v3-rev20191117-1.30.3  [:server:modules:wnprc-modules:WNPRC_EHR]
  com.google.code.findbugs:jsr305 has 2 versions as follows:
    1.3.9  [:server:modules:cloud, :server:modules:fileTransfer, :server:modules:harvest, :server:modules:saml, :server:modules:scrumtime, :server:modules:BimberLabKeyModules:tcrdb, :server:modules:DiscvrLabKeyModules:SequenceAnalysis, :server:modules:platform:api, :server:modules:platform:internal, :server:modules:wnprc-modules:GoogleDrive]
    3.0.2  [:server:modules:wnprc-modules:WNPRC_EHR]
  com.google.j2objc:j2objc-annotations has 2 versions as follows:
    1.1  [:server:modules:cloud, :server:modules:harvest, :server:modules:saml, :server:modules:scrumtime, :server:modules:BimberLabKeyModules:tcrdb, :server:modules:DiscvrLabKeyModules:SequenceAnalysis, :server:modules:platform:api, :server:modules:platform:internal, :server:modules:wnprc-modules:GoogleDrive]
    1.3  [:server:modules:wnprc-modules:WNPRC_EHR]
  com.google.http-client:google-http-client has 2 versions as follows:
    1.23.0  [:server:modules:fileTransfer, :server:modules:harvest, :server:modules:scrumtime, :server:modules:wnprc-modules:GoogleDrive]
    1.34.0  [:server:modules:wnprc-modules:WNPRC_EHR]
```

#### Related Pull Requests
* #77 

#### Changes
* Update dependencies to prevent version conflicts with other modules
