### PR TITLE
Dependency version updates for 21.7 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ docker/nginx/key.pem
 **/build/
 
 **/resources/credits/dependencies.txt
+Gringots/resources/credits/jars.txt
+WNPRC_Compliance/resources/credits/jars.txt
+wnprc_billing/resources/credits/jars.txt
 
 **/.gradle
 

--- a/Gringotts/build.gradle
+++ b/Gringotts/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
 
 dependencies {
 
@@ -10,7 +11,41 @@ dependencies {
     apiExternal "joda-time:joda-time:2.8.1"
     implementation "javax.servlet:jsp-api:2.0"
     implementation files(apiJar)
-    external "org.jooq:jooq:3.8.4"
-    external "org.apache.commons:commons-collections4:${commonsCollections4Version}"
-    external "joda-time:joda-time:2.8.1"
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "org.jooq:jooq:3.8.4",
+                    "jOOQ",
+                    "jOOQ.org",
+                    "https://www.jooq.org/",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "Database-mapping for Java"
+            )
+    )
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "joda-time:joda-time:2.8.1",
+                    "Joda-Time",
+                    "Joda.org",
+                    "http://www.joda.org/joda-time",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "Tools for dealing with dates/times in Java"
+            )
+    )
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "org.apache.commons:commons-collections4:${commonsCollections4Version}",
+                    "Apache Commons Collections",
+                    "Apache",
+                    "https://commons.apache.org/proper/commons-collections/index.html",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "Tools for managing Java collections"
+            )
+    )
+
 }

--- a/Gringotts/resources/credits/jars.txt
+++ b/Gringotts/resources/credits/jars.txt
@@ -1,6 +1,6 @@
 {table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-commons-collections4-4.2.jar|Apache Commons Collections|4.2|{link:From Apache|https://git-wip-us.apache.org/repos/asf?p=commons-collections.git}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Tools for managing Java collections
-joda-time-2.8.1.jar|Joda-Time|2.8.1|{link:From GitHub|https://github.com/JodaOrg/joda-time}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Tools for dealing with dates/times in Java
-jooq-3.8.4.jar|jOOQ|3.8.4|{link:From GitHub|https://github.com/jOOQ/jOOQ}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Database-mapping for Java
+Filename|Component|Source|License|Purpose
+jooq-3.8.4.jar|jOOQ|{link:jOOQ.org|https://www.jooq.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Database-mapping for Java
+joda-time-2.8.1.jar|Joda-Time|{link:Joda.org|http://www.joda.org/joda-time}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Tools for dealing with dates/times in Java
+commons-collections4-4.4.jar|Apache Commons Collections|{link:Apache|https://commons.apache.org/proper/commons-collections/index.html}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Tools for managing Java collections
 {table}

--- a/Gringotts/resources/credits/jars.txt
+++ b/Gringotts/resources/credits/jars.txt
@@ -1,6 +1,0 @@
-{table}
-Filename|Component|Source|License|Purpose
-jooq-3.8.4.jar|jOOQ|{link:jOOQ.org|https://www.jooq.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Database-mapping for Java
-joda-time-2.8.1.jar|Joda-Time|{link:Joda.org|http://www.joda.org/joda-time}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Tools for dealing with dates/times in Java
-commons-collections4-4.4.jar|Apache Commons Collections|{link:Apache|https://commons.apache.org/proper/commons-collections/index.html}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Tools for managing Java collections
-{table}

--- a/WNPRC_Compliance/build.gradle
+++ b/WNPRC_Compliance/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
 
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
@@ -7,8 +8,30 @@ dependencies {
     implementation project("${project.parent.path}:DBUtils")
     implementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
     implementation "javax.servlet:jsp-api:2.0"
-    external "org.jooq:jooq:3.8.4"
-    external "org.apache.pdfbox:pdfbox:${pdfboxVersion}"
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "org.jooq:jooq:3.8.4",
+                    "jOOQ",
+                    "jOOQ.org",
+                    "https://www.jooq.org/",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "Database-mapping for Java"
+            )
+    )
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "org.apache.pdfbox:pdfbox:${pdfboxVersion}",
+                    "Apache PDFBox",
+                    "Apache",
+                    "http://svn.apache.org/repos/asf/pdfbox/trunk/",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "Generates and manipulates PDFs"
+            )
+    )
     jspImplementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
     jspImplementation project( BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"))
 

--- a/WNPRC_Compliance/resources/credits/jars.txt
+++ b/WNPRC_Compliance/resources/credits/jars.txt
@@ -1,5 +1,5 @@
 {table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-jooq-3.8.4.jar|jOOQ|3.8.4|{link:From GitHub|https://github.com/jOOQ/jOOQ}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Database-mapping for Java
-pdfbox-2.0.11.jar|Apache PDFBox|2.0.11|{link:From Apache|http://svn.apache.org/repos/asf/pdfbox/trunk/}|{link:Apache Software License 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jrichardson|Generates and manipulates PDFs
+Filename|Component|Source|License|Purpose
+jooq-3.8.4.jar|jOOQ|{link:jOOQ.org|https://www.jooq.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Database-mapping for Java
+pdfbox-2.0.23.jar|Apache PDFBox|{link:Apache|http://svn.apache.org/repos/asf/pdfbox/trunk/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Generates and manipulates PDFs
 {table}

--- a/WNPRC_Compliance/resources/credits/jars.txt
+++ b/WNPRC_Compliance/resources/credits/jars.txt
@@ -1,5 +1,0 @@
-{table}
-Filename|Component|Source|License|Purpose
-jooq-3.8.4.jar|jOOQ|{link:jOOQ.org|https://www.jooq.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Database-mapping for Java
-pdfbox-2.0.23.jar|Apache PDFBox|{link:Apache|http://svn.apache.org/repos/asf/pdfbox/trunk/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Generates and manipulates PDFs
-{table}

--- a/wnprc_billing/build.gradle
+++ b/wnprc_billing/build.gradle
@@ -1,10 +1,46 @@
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
 
 dependencies {
     implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
-    external "com.koadweb.javafpdf:java-fpdf:${javafpdfVersion}"
-    external("org.apache.sanselan:sanselan:${sanselanVersion}")
-    external "commons-net:commons-net:${commonsNetVersion}"
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "com.koadweb.javafpdf:java-fpdf:${javafpdfVersion}",
+                    "Java-FPDF PDF generation library",
+                    "Java-FPDF",
+                    "https://github.com/nkiraly/Java-FPDF",
+                    ExternalDependency.BSD_2_LICENSE_NAME,
+                    ExternalDependency.BSD_2_LICENSE_URL,
+                    "Used to generate PDF invoices"
+            )
+    )
+
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "org.apache.sanselan:sanselan:${sanselanVersion}",
+                    "Apache Commons Imaging",
+                    "Sanselan",
+                    "https://commons.apache.org/proper/commons-imaging/",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "Required by Java-FPDF"
+            )
+    )
+
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "commons-net:commons-net:${commonsNetVersion}",
+                    "Commons Net",
+                    "Apache",
+                    "http://jakarta.apache.org/commons/net/",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "FTPClient used to retrieve resources from other servers (e.g., GO annotations)"
+            )
+    )
 
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr_billing", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")

--- a/wnprc_billing/resources/credits/jars.txt
+++ b/wnprc_billing/resources/credits/jars.txt
@@ -1,6 +1,6 @@
 {table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-commons-net-3.5.jar|Commons Net|3.3|{link:Apache|http://jakarta.apache.org/commons/net/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jeckels|FTPClient used to retrieve resources from other servers (e.g., GO annotations)
-java-fpdf-1.6.0.jar|Java-FPDF PDF generation library|1.6.0|{link:Java-FPDF|https://github.com/nkiraly/Java-FPDF}|{link:BSD 2|https://github.com/nkiraly/Java-FPDF/blob/master/LICENSE.md}|jeckels|Used to generate PDF invoices
-sanselan-0.97-incubator.jar|Apache Commons Imaging|0.97|{link:Sanselan|https://commons.apache.org/proper/commons-imaging/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jeckels|Required by Java-FPDF
+Filename|Component|Source|License|Purpose
+java-fpdf-1.6.0.jar|Java-FPDF PDF generation library|{link:Java-FPDF|https://github.com/nkiraly/Java-FPDF}|{link:BSD 2|https://opensource.org/licenses/BSD-2-Clause}|Used to generate PDF invoices
+sanselan-0.97-incubator.jar|Apache Commons Imaging|{link:Sanselan|https://commons.apache.org/proper/commons-imaging/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Required by Java-FPDF
+commons-net-3.8.0.jar|Commons Net|{link:Apache|http://jakarta.apache.org/commons/net/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|FTPClient used to retrieve resources from other servers (e.g., GO annotations)
 {table}

--- a/wnprc_billing/resources/credits/jars.txt
+++ b/wnprc_billing/resources/credits/jars.txt
@@ -1,6 +1,0 @@
-{table}
-Filename|Component|Source|License|Purpose
-java-fpdf-1.6.0.jar|Java-FPDF PDF generation library|{link:Java-FPDF|https://github.com/nkiraly/Java-FPDF}|{link:BSD 2|https://opensource.org/licenses/BSD-2-Clause}|Used to generate PDF invoices
-sanselan-0.97-incubator.jar|Apache Commons Imaging|{link:Sanselan|https://commons.apache.org/proper/commons-imaging/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Required by Java-FPDF
-commons-net-3.8.0.jar|Commons Net|{link:Apache|http://jakarta.apache.org/commons/net/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|FTPClient used to retrieve resources from other servers (e.g., GO annotations)
-{table}


### PR DESCRIPTION
#### Rationale
Keeping dependency versions updated.  We also take this opportunity to transition some of the modules to use the new `BuildUtils.addExternalDependency` method that provides the information to be used in populating the `jars.txt` file so we can remove the ones we now generate from git.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2352

#### Changes
* Use `BuildUtils.addExternalDependency`, bringing in version updates.