### PR TITLE
Call Container.hasPermission()

### DIFF
--- a/DBUtils/api-src/org/labkey/dbutils/api/service/SecurityEscalatedService.java
+++ b/DBUtils/api-src/org/labkey/dbutils/api/service/SecurityEscalatedService.java
@@ -48,8 +48,7 @@ public abstract class SecurityEscalatedService {
         this.container = container;
 
         // Check to make sure our user has all the required permissions
-        SecurityPolicy policy = SecurityPolicyManager.getPolicy(container);
-        if(requiredPermissions.length > 0 && !policy.hasPermissions(user, requiredPermissions)) {
+        if (requiredPermissions.length > 0 && !container.hasPermissions(user, new HashSet<>(Arrays.asList(requiredPermissions)))) {
             throw MissingPermissionsException.createNew(requiredPermissions);
         }
     }


### PR DESCRIPTION
#### Rationale
Create new permission check choke-point.  Replace/unify Container.hasPermission() and SecurityPolicy.hasPermission()
* SecurityManager.hasAllPermissions()
* SecurityManager.hasAnyPermissions()
* SecurityManager.getPermissions()
* SecurityManager.getPermissionNames()

#### Related Pull Requests
* https://github.com/LabKey/compliance/pull/118
* https://github.com/LabKey/ehrModules/pull/195
* https://github.com/LabKey/snd/pull/97
* https://github.com/LabKey/platform/pull/2359
* https://github.com/LabKey/MacCossLabModules/pull/122
* https://github.com/LabKey/wnprc-modules/pull/86

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->