### PR TITLE
Item 9192: Initial modifications to support sample status

### DIFF
--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
@@ -79,7 +79,7 @@ public class WNPRC_PurchasingManager
 
     public void addQCStatus(Container c, User user)
     {
-        addData(c, user, "core", "QCState", "QCStatus.tsv");
+        addData(c, user, "core", "DataStates", "QCStatus.tsv");
     }
 
     private void addData(Container c, User user, String schemaName, String tableName, String fileName)


### PR DESCRIPTION
#### Rationale
We have renamed the `core.qcstate` table to `core.datastates` for more general use, in particular for supporting sample status values.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2636

#### Changes
* Update references to core.qcstate
