### PR TITLE
Study schema contextual roles

### DIFF
--- a/SelfRegistration/src/org/labkey/selfregistration/SelfRegistrationController.java
+++ b/SelfRegistration/src/org/labkey/selfregistration/SelfRegistrationController.java
@@ -238,7 +238,6 @@ public class SelfRegistrationController extends SpringActionController
             // get issue table and insert the issue row
             UserSchema userSchema = QueryService.get().getUserSchema(user, container, _schemaPath);
             TableInfo table = userSchema.getTable(form.getIssueDefName());
-            QueryService.get().getSelectSQL(table,null,null,null,100,0,false);
             QueryUpdateService qus = table.getUpdateService();
 
             BatchValidationException batchErrors = new BatchValidationException();


### PR DESCRIPTION
#### Rationale
Flush out TableInfo.hasPermission(ReadPermission) implementations
use contextual roles for permission elevation (study schema)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
