### PR TITLE
Issue 44015: Migrate remaining log4j 1.2 usages to 2.x

### DIFF
--- a/SelfRegistration/src/org/labkey/selfregistration/SelfRegistrationController.java
+++ b/SelfRegistration/src/org/labkey/selfregistration/SelfRegistrationController.java
@@ -1,6 +1,7 @@
 package org.labkey.selfregistration;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.junit.*;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
@@ -58,7 +59,7 @@ public class SelfRegistrationController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(SelfRegistrationController.class);
     public static final String NAME = "selfregistration";
-    protected static final Logger _log = Logger.getLogger(SelfRegistrationController.class);
+    protected static final Logger _log = LogManager.getLogger(SelfRegistrationController.class);
 
     public SelfRegistrationController()
     {

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
@@ -18,7 +18,8 @@ package org.labkey.wnprc_ehr;
 import au.com.bytecode.opencsv.CSVWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -136,7 +137,7 @@ import static java.time.temporal.ChronoUnit.DAYS;
 public class WNPRC_EHRController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(WNPRC_EHRController.class);
-    private static Logger _log = Logger.getLogger(WNPRC_EHRController.class);
+    private static Logger _log = LogManager.getLogger(WNPRC_EHRController.class);
 
     public WNPRC_EHRController()
     {

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/data/breeding/PregnancyHistoryCreator.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/data/breeding/PregnancyHistoryCreator.java
@@ -1,6 +1,7 @@
 package org.labkey.wnprc_ehr.data.breeding;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
@@ -46,7 +47,7 @@ public final class PregnancyHistoryCreator
     /**
      * Logger for logging the logs
      */
-    private static final Logger LOG = Logger.getLogger(PregnancyHistoryCreator.class);
+    private static final Logger LOG = LogManager.getLogger(PregnancyHistoryCreator.class);
 
     /**
      * Creates new pregnancy and outcome records in the new datasets based on the existing records in the birth,

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/table/WNPRC_EHRCustomizer.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/table/WNPRC_EHRCustomizer.java
@@ -15,7 +15,8 @@
  */
 package org.labkey.wnprc_ehr.table;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
@@ -67,7 +68,7 @@ import java.util.List;
  */
 public class WNPRC_EHRCustomizer extends AbstractTableCustomizer
 {
-    protected static final Logger _log = Logger.getLogger(WNPRC_EHRCustomizer.class);
+    protected static final Logger _log = LogManager.getLogger(WNPRC_EHRCustomizer.class);
     public WNPRC_EHRCustomizer()
     {
 

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/updates/ModuleUpdate.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/updates/ModuleUpdate.java
@@ -1,6 +1,7 @@
 package org.labkey.wnprc_ehr.updates;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleContext;
@@ -20,7 +21,7 @@ public class ModuleUpdate
     /**
      * Logger for logging the logs
      */
-    private static final Logger LOG = Logger.getLogger(ModuleUpdate.class);
+    private static final Logger LOG = LogManager.getLogger(ModuleUpdate.class);
 
     /**
      * Cached set of {@link Updater} instances reflected from the package

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/updates/UpdateTo15_16.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/updates/UpdateTo15_16.java
@@ -1,6 +1,7 @@
 package org.labkey.wnprc_ehr.updates;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -36,7 +37,7 @@ public class UpdateTo15_16 extends ModuleUpdate.ComparableUpdater
     /**
      * Logger for logging the logs
      */
-    private static final Logger LOG = Logger.getLogger(UpdateTo15_16.class);
+    private static final Logger LOG = LogManager.getLogger(UpdateTo15_16.class);
 
     /**
      * Returns a new animal history report row built from the passed name, title, query, and description as a


### PR DESCRIPTION
#### Rationale
Recent events notwithstanding, we prefer log4j 2.x. Migrate 1.2 usages that were never converted or that snuck in after our big migration.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2899