### PR TITLE
Stop managing schema versions on other WNPRC modules

### DIFF
--- a/WNPRC_Purchasing/module.properties
+++ b/WNPRC_Purchasing/module.properties
@@ -2,3 +2,4 @@ ModuleClass: org.labkey.wnprc_purchasing.WNPRC_PurchasingModule
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: pgsql
+ManageVersion: false

--- a/wnprc_billing/module.properties
+++ b/wnprc_billing/module.properties
@@ -1,3 +1,3 @@
 ModuleClass: org.labkey.wnprc_billing.WNPRC_BillingModule
 SupportedDatabases: pgsql
-ManageVersion: true
+ManageVersion: false

--- a/wnprc_billingpublic/module.properties
+++ b/wnprc_billingpublic/module.properties
@@ -1,2 +1,3 @@
 Name: WNPRC_BillingPublic
 SupportedDatabases: pgsql
+ManageVersion: false


### PR DESCRIPTION
#### Rationale
We periodically hit snags when release branches and develop both have changes to schema versions

#### Changes
* Stop managing schema versions for WNPRC_Purchasing, WNPRC_Billing, and WNPRC_BillingPublic, matching WNPRC_EHR