### PR TITLE
Clean up study.xml files in referenceStudies

### DIFF
--- a/WNPRC_EHR/resources/referenceStudy/study.xml
+++ b/WNPRC_EHR/resources/referenceStudy/study.xml
@@ -7,10 +7,4 @@
   <datasets dir="datasets" file="datasets_manifest.xml">
     <definition file="PrimateElectronicHealthRecord.dataset"/>
   </datasets>
-  <missingValueIndicators>
-    <missingValueIndicator indicator="E" label="Value is estimated."/>
-    <missingValueIndicator indicator="Q" label="Data currently under quality control review."/>
-    <missingValueIndicator indicator="A" label="Data value is abnormal."/>
-    <missingValueIndicator indicator="N" label="Required field marked by site as 'data not available'."/>
-  </missingValueIndicators>
 </study>

--- a/WNPRC_r24/resources/referenceStudy/study.xml
+++ b/WNPRC_r24/resources/referenceStudy/study.xml
@@ -1,18 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <study archiveVersion="11.31" label="wnprc_r24" timepointType="CONTINUOUS" subjectNounSingular="Animal" subjectNounPlural="Animals" subjectColumnName="AnimalId" description="" descriptionRendererType="TEXT_WITH_LINKS" investigator="" grant="" startDate="1990-01-01-06:00" securityType="ADVANCED_WRITE" xmlns="http://labkey.org/study/xml">
-  <!--<lists dir="lists"/>-->
-  <!--<views dir="views"/>-->
-  <!--<reports dir="reports"/>-->
-  <!--<cohorts type="AUTOMATIC" mode="SIMPLE" datasetId="1012" datasetProperty="v_status"/>-->
   <qcStates showPrivateDataByDefault="true"/>
   <datasets dir="datasets" file="datasets_manifest.xml">
     <definition file="wnprc_r24.dataset"/>
   </datasets>
-  <comments/>
-  <missingValueIndicators>
-    <missingValueIndicator indicator="E" label="Value is estimated."/>
-    <missingValueIndicator indicator="Q" label="Data currently under quality control review."/>
-    <missingValueIndicator indicator="A" label="Data value is abnormal."/>
-    <missingValueIndicator indicator="N" label="Required field marked by site as 'data not available'."/>
-  </missingValueIndicators>
 </study>

--- a/WNPRC_u24/resources/referenceStudy/study.xml
+++ b/WNPRC_u24/resources/referenceStudy/study.xml
@@ -1,18 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <study archiveVersion="11.31" label="wnprc_u24" timepointType="CONTINUOUS" subjectNounSingular="Animal" subjectNounPlural="Animals" subjectColumnName="AnimalId" description="" descriptionRendererType="TEXT_WITH_LINKS" investigator="" grant="" startDate="1990-01-01-06:00" securityType="ADVANCED_WRITE" xmlns="http://labkey.org/study/xml">
-  <!--<lists dir="lists"/>-->
-  <!--<views dir="views"/>-->
-  <!--<reports dir="reports"/>-->
-  <!--<cohorts type="AUTOMATIC" mode="SIMPLE" datasetId="1012" datasetProperty="v_status"/>-->
   <qcStates showPrivateDataByDefault="true"/>
   <datasets dir="datasets" file="datasets_manifest.xml">
     <definition file="wnprc_u24.dataset"/>
   </datasets>
-  <comments/>
-  <missingValueIndicators>
-    <missingValueIndicator indicator="E" label="Value is estimated."/>
-    <missingValueIndicator indicator="Q" label="Data currently under quality control review."/>
-    <missingValueIndicator indicator="A" label="Data value is abnormal."/>
-    <missingValueIndicator indicator="N" label="Required field marked by site as 'data not available'."/>
-  </missingValueIndicators>
 </study>


### PR DESCRIPTION
#### Rationale
`<missingValueIndicators>` element is no longer supported in `study.xml`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2925