### PR TITLE
Fix for test timing issues.

### DIFF
--- a/WNPRC_Purchasing/test/src/org/labkey/test/Pages/CreateRequestPage.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/Pages/CreateRequestPage.java
@@ -18,6 +18,13 @@ public class CreateRequestPage extends LabKeyPage<CreateRequestPage.ElementCache
         super(driver);
     }
 
+    @Override
+    protected void waitForPage()
+    {
+        Locator.waitForAnyElement(shortWait(), Locator.tagWithClass("div", "panel-title").withText("Request Info"),
+                Locator.tagWithClass("div", "panel-title").withText("Requested Items"));
+    }
+
     public String getAccountsToCharge()
     {
         return shortWait().ignoring(NoSuchElementException.class).until(wd ->

--- a/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
@@ -63,6 +63,7 @@ import static org.labkey.test.WebTestHelper.buildRelativeUrl;
 import static org.labkey.test.WebTestHelper.getRemoteApiConnection;
 
 @Category({EHR.class, WNPRC_EHR.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresOnlyTest
 {
     //folders
@@ -709,7 +710,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         emailApprovalRequest.put("Unit", "Term");
         emailApprovalRequest.put("Unit Cost", "500");
         emailApprovalRequest.put("Quantity", "10");
-        clickAndWait(Locator.linkWithText("Create Request"));
+        waitAndClickAndWait(Locator.linkWithText("Create Request"));
         String requestId = createRequest(emailApprovalRequest, null);
         stopImpersonating();
 
@@ -725,6 +726,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         checker().verifyTrue("Incorrect email body",
                 mailTable.getMessage(subject).getBody().contains("A new purchasing request # " + requestId + " by " + requester2Name + " was submitted on " + _dateTimeFormatter.format(today) + " for the total of $5,000.00."));
         checker().screenShotIfNewError("request_submitted_email");
+
         log("Delete emails from dumbster");
         enableEmailRecorder();
 
@@ -764,7 +766,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         emailApprovalRequest.put("Unit", "Term");
         emailApprovalRequest.put("Unit Cost", "500");
         emailApprovalRequest.put("Quantity", "20");
-        clickAndWait(Locator.linkWithText("Create Request"));
+        waitAndClickAndWait(Locator.linkWithText("Create Request"));
         String requestId = createRequest(emailApprovalRequest, null);
         stopImpersonating();
 
@@ -818,7 +820,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         emailApprovalRequest.put("Unit", "Term");
         emailApprovalRequest.put("Unit Cost", "500");
         emailApprovalRequest.put("Quantity", "20");
-        clickAndWait(Locator.linkWithText("Create Request"));
+        waitAndClickAndWait(Locator.linkWithText("Create Request"));
         String requestId = createRequest(emailApprovalRequest, null);
         stopImpersonating();
 


### PR DESCRIPTION
#### Rationale
Updating the test with appropriate wait for elements

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
1.  Added waitforPage() in WNPRC_Purchasing/test/src/org/labkey/test/Pages/CreateRequestPage.java
2.  Replaced clickAndWait with waitAndClickAndWait
