### PR TITLE
Remove unused <categories> elements from datasets_manifest.xml files in sample archives

### DIFF
--- a/WNPRC_EHR/resources/pregnancySubsetReferenceStudy/study/datasets/datasets_manifest.xml
+++ b/WNPRC_EHR/resources/pregnancySubsetReferenceStudy/study/datasets/datasets_manifest.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <datasets metaDataFile="datasets_metadata.xml" xmlns="http://labkey.org/study/xml">
-    <categories>
-        <category>Colony Management</category>
-    </categories>
     <datasets>
         <dataset name="breeding_encounters" id="6000" category="Colony Management" type="Standard"/>
         <dataset name="pregnancies"         id="6001" category="Colony Management" type="Standard"/>

--- a/WNPRC_EHR/resources/referenceStudy/study/datasets/datasets_manifest.xml
+++ b/WNPRC_EHR/resources/referenceStudy/study/datasets/datasets_manifest.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <datasets metaDataFile="datasets_metadata.xml" xmlns="http://labkey.org/study/xml">
-  <categories>
-    <category>Clinical</category>
-    <category>ColonyManagement</category>
-    <category>ClinPath</category>
-    <category>Pathology</category>
-  </categories>
   <datasets>
     <dataset name="alopecia" id="1061" category="Clinical"/>
     <dataset name="ActiveHousing" id="5010" showByDefault="false" category="ColonyManagement" demographicData="true"/>


### PR DESCRIPTION
#### Rationale
Support for unused `<categories>` element has been removed

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3062