### PR TITLE
Ticket 44877: Purchasing module - Reorder button sets status to Order Received rather than Review Pending 

### DIFF
--- a/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
+++ b/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
@@ -164,7 +164,7 @@ export const App: FC = memo(() => {
                             controlledSubstance: val.controlledSubstance,
                             itemUnit: val.itemUnitId,
                             quantity: val.quantity,
-                            quantityReceived: val.quantityReceived,
+                            quantityReceived: isReorder ? 0 : val.quantityReceived,
                             unitCost: val.unitCost,
                             status: val.itemStatusId,
                         });


### PR DESCRIPTION
#### Rationale
Ticket [44877](https://www.labkey.org/WNPRC/support%20tickets/issues-details.view?issueId=44877): Purchasing module - Reorder button sets status to Order Received rather than Review Pending 

Reordering a request that was already received (i.e. quantity received = quantity requested, which then sets the qc status to 'Order Received') doesn't reset qc state to 'Review Pending', instead it keeps it 'Order Received'.

#### Changes
* Reset 'quantity received' when reordering, which allows for the qc state to be 'Review Pending'.
