### PR TITLE
Fix WNPRC_EHRTest - don't override getDisplayValue() needlessly

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/table/WNPRC_EHRCustomizer.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/table/WNPRC_EHRCustomizer.java
@@ -225,12 +225,6 @@ public class WNPRC_EHRCustomizer extends AbstractTableCustomizer
                             super.renderGridCellContents(ctx, out);
                         }
                     }
-
-                    @Override
-                    public Object getDisplayValue(RenderContext ctx)
-                    {
-                        return ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "rowid"));
-                    }
                 });
             }
         }


### PR DESCRIPTION
#### Rationale
We improved the behavior of DataColumn so that getDisplayValue() is used as the display value in more scenarios. And we don't actually want to be customizing the display value in this case.

#### Changes
* Stop trying to swap in the RowId as the display value for the updateTitle column!