### PR TITLE
Convert performedBy userIds to user display names in obs dataset

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
@@ -18,8 +18,8 @@ package org.labkey.wnprc_ehr;
 import au.com.bytecode.opencsv.CSVWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -36,16 +36,21 @@ import org.labkey.api.action.SimpleRedirectAction;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.RuntimeSQLException;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
+import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.ehr.EHRDemographicsService;
 import org.labkey.api.ehr.EHRService;
 import org.labkey.api.ehr.demographics.AnimalRecord;
+import org.labkey.api.exp.property.Domain;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.BatchValidationException;
@@ -68,6 +73,8 @@ import org.labkey.api.security.RequiresSiteAdmin;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.study.Dataset;
+import org.labkey.api.study.StudyService;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.URLHelper;
@@ -79,6 +86,7 @@ import org.labkey.googledrive.api.DriveWrapper;
 import org.labkey.googledrive.api.FolderWrapper;
 import org.labkey.googledrive.api.GoogleDriveService;
 import org.labkey.security.xml.GroupEnumType;
+import org.labkey.study.StudySchema;
 import org.labkey.webutils.api.action.SimpleJspPageAction;
 import org.labkey.webutils.api.action.SimpleJspReportAction;
 import org.labkey.webutils.api.json.EnhancedJsonResponse;
@@ -2195,5 +2203,41 @@ public class WNPRC_EHRController extends SpringActionController
         rs.close();
         return woRows;
 
+    }
+
+    @RequiresPermission(AdminPermission.class)
+    public class CorrectObsUserIdsAction extends MutatingApiAction<Object>
+    {
+        @Override
+        public Object execute(Object o, BindException errors) throws Exception
+        {
+            DbSchema studySchema = StudySchema.getInstance().getSchema();
+            Dataset obsDataset = StudyService.get().getStudy(getContainer()).getDatasetByName("obs");
+//            TableInfo obsTable = studySchema.getTable("obs");
+
+            if (null == obsDataset)
+            {
+                errors.reject(ERROR_MSG, "study.obs dataset not found. Ensure you are in the right folder.");
+                return false;
+            }
+
+            Domain obsDomain = obsDataset.getTableInfo(getUser()).getDomain();
+            if (null == obsDomain)
+            {
+                errors.reject(ERROR_MSG, "study.obs domain not found.");
+                return false;
+            }
+
+            SQLFragment sql = new SQLFragment("UPDATE studydataset.").append(obsDomain.getStorageTableName()).append(" o SET performedBy = s.performedBy FROM (\n ")
+                    .append("SELECT ob.lsid, COALESCE(ud.displayname, ob.performedBy) as performedBy FROM ").append(obsDataset.getTableInfo(getUser()), "ob").append("\n")
+                    .append("LEFT JOIN ").append(CoreSchema.getInstance().getTableInfoUsersData(),"ud").append(" ON CAST(ud.userid AS VARCHAR) = ob.performedBy\n")
+                    .append(") s WHERE s.lsid = o.lsid");
+
+            new SqlExecutor(studySchema).execute(sql);
+
+            ApiSimpleResponse response = new ApiSimpleResponse();
+            response.put("success", true);
+            return response;
+        }
     }
 }

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
@@ -2205,6 +2205,9 @@ public class WNPRC_EHRController extends SpringActionController
 
     }
 
+    /* TODO: This is an API to clean up an inconsistency in the performed by column of study.obs dataset. Once the
+     underlying issue is resolved, this API can be deleted.
+     */
     @RequiresPermission(AdminPermission.class)
     public class CorrectObsUserIdsAction extends MutatingApiAction<Object>
     {


### PR DESCRIPTION
#### Rationale
API to update all performedBy values in study.obs dataset.  If the value is a userId, the user displayname will be put in to the column, else the value will be unchanged. 

POST API can be called directly from console or a script.
`LABKEY.Ajax.request({
            url: LABKEY.ActionURL.buildURL('wnprc_ehr', 'correctObsUserIds.api'),
            method: 'POST',
	    success: function() {console.log('It worked, woohoo!')},
	    failure: LABKEY.Utils.getCallbackWrapper(function (response) {console.error('Failed: ' + response.exception)})
});`

#### Changes
* Add WNPRC_EHR.CorrectObsUserIdsAction
