### PR TITLE
LSID value not found in table - throw exception to report error in the log and to the user

### DIFF
--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
@@ -116,7 +116,7 @@ public class WNPRC_PurchasingManager
         }
     }
 
-    public List<ValidationException> submitRequestForm(User user, Container container, WNPRC_PurchasingController.RequestForm requestForm)
+    public List<ValidationException> submitRequestForm(User user, Container container, WNPRC_PurchasingController.RequestForm requestForm) throws Exception
     {
         UserSchema us = QueryService.get().getUserSchema(user, container, "ehr_purchasing");
         boolean isNewRequest = null == requestForm.getRowId();
@@ -333,10 +333,9 @@ public class WNPRC_PurchasingManager
         }
         catch (Exception e)
         {
-            List<ValidationException> rowErrors = new ArrayList<>();
-            rowErrors.add(new ValidationException().addError(new SimpleValidationError(e.getMessage())));
-            return rowErrors;
+            throw new Exception(e.getMessage(), e);// is there a less generic exception to use to capture exceptions from insertRows, updateRows, and deleteRows in addition to other exceptions (like IllegalStateException)?
         }
+
         return validationErrors;
     }
 

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
@@ -331,10 +331,6 @@ public class WNPRC_PurchasingManager
 
             transaction.commit();
         }
-        catch (Exception e)
-        {
-            throw new Exception(e.getMessage(), e);// is there a less generic exception to use to capture exceptions from insertRows, updateRows, and deleteRows in addition to other exceptions (like IllegalStateException)?
-        }
 
         return validationErrors;
     }


### PR DESCRIPTION
#### Rationale
Submitting a wnprc purchasing request form with extensible columns throws "java.lang.IllegalStateException: LSID value not found in table - purchasingRequests".
This error was not shown to the user nor was in labkey log to be able to debug (only place it was showing was in the browser debugger console)

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/363

#### Changes
* Throw exception to report error in the log and to the user