### PR TITLE
Ticket 45691: WNPRC_Purchasing: Deleting line items while reordering a purchase also deletes that line item from the original order

### DIFF
--- a/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
+++ b/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
@@ -248,7 +248,7 @@ export const App: FC = memo(() => {
             setLineItems(lineItemArray);
             setIsDirty(true);
 
-            if (rowIdToDelete) {
+            if (rowIdToDelete && !isReorder) {
                 const updatedRowsToDelete = produce(lineItemRowsToDelete, (draft: Draft<number[]>) => {
                     draft.push(rowIdToDelete);
                 });


### PR DESCRIPTION
#### Rationale
Ticket [45691](https://www.labkey.org/WNPRC/support%20tickets/issues-details.view?issueId=45691): WNPRC_Purchasing: Deleting line items while reordering a purchase also deletes that line item from the original order

#### Changes
* Add a condition so that the line items will get sent to the server for deletion only if it is a existing request and not a reorder.