### PR TITLE
Fix invalid cron expression

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/FoodNotCompletedNotification.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/FoodNotCompletedNotification.java
@@ -23,7 +23,7 @@ import static java.lang.Math.toIntExact;
 
 public class FoodNotCompletedNotification extends AbstractEHRNotification
 {
-    protected String cronString = "0 0/60 6-21 * * ?";
+    protected String cronString = "0 0 6-21 * * ?";
 
 
     public FoodNotCompletedNotification(Module owner){


### PR DESCRIPTION
#### Rationale
Quartz upgrade flagged `FoodNotCompletedNotification`'s cron expression as invalid. I think this is what was intended.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/310
