### PR TITLE
Upgrade Google Client API 1.35.2 -> 2.0.0

### DIFF
--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -148,8 +148,5 @@ configurations.all {
     Configuration config ->
         resolutionStrategy {
             force "org.javassist:javassist:${javassistVersion}"
-
-            // Conflicts with other versions
-            force "com.google.http-client:google-http-client-gson:${googleHttpClientGsonVersion}"
         }
 }


### PR DESCRIPTION
#### Rationale
We're forcing the latest Google HTTP GSON at the top level now

#### Related Pull Requests
* https://github.com/LabKey/server/pull/316
