### PR TITLE
Issue 46263: Error when deleting a folder or workbook within EHR due to wnprc.session_log

### DIFF
--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.000-22.001.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.000-22.001.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS wnprc.session_log
+(
+    rowid                   serial NOT NULL,
+    start_time              TIMESTAMP,
+    end_time                TIMESTAMP,
+    schema_name             varchar(100),
+    query_name              varchar(100),
+    task_id                 varchar(255),
+    number_of_records       integer,
+    batch_add_used          boolean,
+    bulk_edit_used          boolean,
+    user_agent              varchar(255),
+    errors_occurred         boolean,
+    form_framework_type     integer,
+
+    -- Default fields for LabKey.
+    container         entityid NOT NULL,
+    createdby         userid,
+    created           TIMESTAMP,
+    modifiedby        userid,
+    modified          TIMESTAMP,
+
+    CONSTRAINT pk_session_log_rowid PRIMARY KEY (rowid),
+    CONSTRAINT fk_session_log_form_framework_type FOREIGN KEY (form_framework_type) REFERENCES ehr.form_framework_types (rowid)
+);
+

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -179,7 +179,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
 
     @Override
     public @Nullable Double getSchemaVersion() {
-        return forceUpdate ? Double.POSITIVE_INFINITY : 21.006;
+        return forceUpdate ? Double.POSITIVE_INFINITY : 22.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
wnprc.session_log was added via wnprc-18.36-18.37.sql. When it got merged to newer releases, its numbering caused it to not run on some existing DBs. It was successfully incorporated into the bootstrap versions of the script, meaning it's been passing on TeamCity's checks for DB vs expected tables.

#### Changes
* Add the table if it's not already there