### PR TITLE
Make NPM build output work with Gradle cache

### DIFF
--- a/AnimalRequests/package.json
+++ b/AnimalRequests/package.json
@@ -84,7 +84,7 @@
       }
     },
     "clean": {
-      "command": "rimraf resources/web/animalrequests/gen ; rimraf node_modules"
+      "command": "rimraf resources/web/AnimalRequests/gen ; rimraf node_modules"
     },
     "build-jest-test": {
       "command": "jest",

--- a/AnimalRequests/webpack.config.js
+++ b/AnimalRequests/webpack.config.js
@@ -28,7 +28,7 @@ module.exports  = [function wp() {
             library: 'AnimalRequests',
             libraryExport: 'default',
             libraryTarget: 'umd',
-            path: path.resolve(__dirname, 'resources/web/animalrequests/gen/')
+            path: path.resolve(__dirname, 'resources/web/AnimalRequests/gen/')
         },
         resolve: {
             extensions: ['.ts', '.tsx', '.js', '.json', '.css'],

--- a/AnimalRequests/webpack/dev-style.config.js
+++ b/AnimalRequests/webpack/dev-style.config.js
@@ -11,7 +11,7 @@ module.exports = {
     },
 
     output: {
-        path: path.resolve(__dirname, '../resources/web/animalrequests/app/'),
+        path: path.resolve(__dirname, '../resources/web/AnimalRequests/gen/'),
         publicPath: '/',
         filename: 'style.js' // do not override app.js
     },

--- a/AnimalRequests/webpack/dev.config.js
+++ b/AnimalRequests/webpack/dev.config.js
@@ -16,7 +16,7 @@ module.exports = {
     },
 
     output: {
-        path: path.resolve(__dirname, '../resources/web/animalrequests/app/'),
+        path: path.resolve(__dirname, '../resources/web/AnimalRequests/gen/'),
         publicPath: 'http://localhost:3000/',
         filename: '[name].js'
     },

--- a/AnimalRequests/webpack/prod.config.js
+++ b/AnimalRequests/webpack/prod.config.js
@@ -47,8 +47,7 @@ module.exports = {
     },
 
     output: {
-        path: path.resolve(__dirname, '../resources/web/animalrequests/gen/app/'),
-        //path: path.resolve(__dirname, '../../WNPRC_EHR/resources/web/wnprc_ehr/reactjs/animalrequests/'),
+        path: path.resolve(__dirname, '../resources/web/AnimalRequests/gen/'),
         publicPath: './', // allows context path to resolve in both js/css
         filename: "[name].js"
     },

--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -49,3 +49,9 @@ configurations.all {
             force "com.google.http-client:google-http-client:${googleHttpClientVersion}"
         }
 }
+
+// Declare atypical npm build output directory for Gradle to correctly cache output
+List.of(project.tasks.named("npm_run_build-prod"), project.tasks.named("npm_run_build"))
+        .forEach(task -> task.configure {
+            outputs.dir(project.file("./resources/web/wnprc_ehr/gen"))
+        })

--- a/WNPRC_EHR/package.json
+++ b/WNPRC_EHR/package.json
@@ -12,7 +12,7 @@
     "build-storybook": "build-storybook",
     "build": "better-npm-run build",
     "build-prod": "better-npm-run build-prod",
-    "clean": "rm -rf resources/web/gen; rm -rf resources/views/gen"
+    "clean": "rm -rf resources/web/wnprc_ehr/gen; rm -rf resources/views/gen"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
#### Rationale
The client sources are in the correct place now but the NPM build output location isn't what Gradle expects (`resources/web/wnprc_ehr/gen` instead of `resources/web/WNPRC_EHR/gen`). Similar for `AnimalRequests`. I've moved the `AnimalRequests` output to the typical location but it was simpler to teach Gradle about the output location for `WNPRC_EHR` since there is so much non-generated code referencing the current location.

#### Related Pull Requests
* #225 

#### Changes
* Configure output directories for NPM build tasks
* Use standard directory for `AnimalRequests` NPM output
