### PR TITLE
Preserve lowercase handling of animal Ids

### DIFF
--- a/WNPRC_EHR/resources/web/wnprc_ehr/wnprcOverRides.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/wnprcOverRides.js
@@ -98,6 +98,12 @@ WNPRC_EHR.ProjectField2 = Ext.extend(LABKEY.ext.ComboBox, {
     }
 });
 
+EHR.Utils.formatAnimalIds = function(subjects) {
+    return subjects.map(element => {
+        return element.toLowerCase();
+    });
+}
+
 Ext.reg('ehr-project_2', WNPRC_EHR.ProjectField2);
 
 EHR.Metadata.Columns['Irregular Observations'] = 'id/curlocation/location,id,id/curlocation/cond,date,enddate,inRoom,feces,menses,other,tlocation,other,breeding,' + EHR.Metadata.bottomCols + ',behavior,otherbehavior';

--- a/WNPRC_EHR/resources/web/wnprc_ehr/wnprcOverRides.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/wnprcOverRides.js
@@ -98,6 +98,10 @@ WNPRC_EHR.ProjectField2 = Ext.extend(LABKEY.ext.ComboBox, {
     }
 });
 
+
+/** This forces animal Ids to lowercase in UI components like animal history, animal search,
+ *  and data entry windows. This is no longer the default formatting in EHR so overriding this locally.
+ */
 EHR.Utils.formatAnimalIds = function(subjects) {
     return subjects.map(element => {
         return element.toLowerCase();


### PR DESCRIPTION
#### Rationale
EHR has been updated to not force animal Ids to lowercase in several UI components like animal history, animal search and data entry bulk forms. This change adds a formatting function for wnprc to keep consistent behavior as before the EHR change.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/457

#### Changes
* Add animal id formatting function to force lowercase
