### PR TITLE
Issue 46855: Schema mismatch for wnprc_purchasing.purchaseOptions

### DIFF
--- a/WNPRC_Purchasing/resources/schemas/dbscripts/postgresql/wnprc_purchasing-22.000-22.001.sql
+++ b/WNPRC_Purchasing/resources/schemas/dbscripts/postgresql/wnprc_purchasing-22.000-22.001.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS wnprc_purchasing.creditCardOptions;
+
+CREATE TABLE IF NOT EXISTS wnprc_purchasing.paymentOptions
+(
+    rowId       serial,
+    paymentOption  varchar(500),
+    container   ENTITYID NOT NULL,
+    createdBy   USERID,
+    created     timestamp,
+    modifiedBy  USERID,
+    modified    timestamp,
+
+    CONSTRAINT PK_WNPRC_PURCHASING_PAYMENT_OPTIONS PRIMARY KEY (rowId),
+    CONSTRAINT FK_WNPRC_PURCHASING_PAYMENT_OPTIONS_CONTAINER FOREIGN KEY (Container) REFERENCES core.Containers (EntityId)
+);
+
+CREATE INDEX IF NOT EXISTS IDX_WNPRC_PURCHASING_PAYMENT_OPTIONS_CONTAINER ON wnprc_purchasing.paymentOptions(Container);

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingModule.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingModule.java
@@ -48,7 +48,7 @@ public class WNPRC_PurchasingModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.000;
+        return 22.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The upgrade script that created the purchaseOptions table didn't run on a server due to the version having already been bumped in a later release branch.

#### Changes
* Conditionally rerun the script to get to the expected schema