### PR TITLE
Migrate to new JSONObject/JSONArray library

### DIFF
--- a/GoogleDrive/src/org/labkey/googledrive/GoogleDriveController.java
+++ b/GoogleDrive/src/org/labkey/googledrive/GoogleDriveController.java
@@ -1,7 +1,7 @@
 package org.labkey.googledrive;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.SimpleApiJsonForm;
 import org.labkey.api.action.SimpleViewAction;
@@ -84,8 +84,7 @@ public class GoogleDriveController extends SpringActionController {
         @Override
         public Object execute(SimpleApiJsonForm form, BindException errors) throws Exception {
             ObjectMapper mapper = new ObjectMapper();
-            JSONObject object = (form.getJsonObject() == null) ? new JSONObject() : form.getJsonObject();
-
+            JSONObject object = (form.getNewJsonObject() == null) ? new JSONObject() : form.getNewJsonObject();
 
             RegisterServiceAccountForm registerForm = mapper.readValue(object.toString(), RegisterServiceAccountForm.class);
 


### PR DESCRIPTION
#### Rationale
We want to use the new `org.json.JSON*` library