### PR TITLE
Fix various WNPRC test failures

### DIFF
--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -16,6 +16,7 @@
 package org.labkey.test.tests.wnprc_ehr;
 
 import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -2152,8 +2153,9 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         _customizeViewsHelper.applyCustomView();
         DataRegionTable auditTable =  new DataRegionTable("query", this);
         String auditLog = auditTable.getDataAsText(0,"DataChanges");
-        assertTrue("entry didn't contain \"paymentamountreceived:  » 1028.95\"\n" + auditLog, auditLog.contains("paymentamountreceived:  » 1028.95"));
-        assertTrue("entry didn't contain \"balancedue:  » 0.0\"\n" + auditLog, auditLog.contains("balancedue:  » 0.0"));
+        Assertions.assertThat(auditLog).as("Audit entry for ehr_billing.invoice")
+                .contains("paymentamountreceived:  \u00BB 1028.95")
+                .contains("balancedue:  \u00BB 0.0");
     }
 
     @Test

--- a/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
@@ -477,7 +477,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         beginAt(buildRelativeUrl("WNPRC_Purchasing", getProjectName(), "requestEntry", Maps.of("requestRowId", requestID)));
         log("Impersonate as " + REQUESTER_USER_2);
         impersonate(REQUESTER_USER_2);
-        assertTextPresent("You do not have sufficient permissions to update this request.");
+        waitForText("You do not have sufficient permissions to update this request.");
         stopImpersonating();
     }
 

--- a/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
@@ -35,6 +35,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.EHR;
 import org.labkey.test.categories.WNPRC_EHR;
 import org.labkey.test.componenes.CreateVendorDialog;
+import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.dumbster.EmailRecordTable;
 import org.labkey.test.components.html.SiteNavBar;
 import org.labkey.test.util.APIUserHelper;
@@ -173,9 +174,8 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         selectQuery("ehr_billing", "aliases");
         clickAndWait(Locator.linkWithText("create definition"), 5000);
 
-        Locator.XPathLocator manuallyDefineFieldsLoc = Locator.tagWithClass("div", "domain-form-manual-btn");
-        click(manuallyDefineFieldsLoc);
-        setFormElement(Locator.inputByNameContaining("domainpropertiesrow-name"), extensibleCol);
+        DomainFormPanel domainFormPanel = new DomainFormPanel.DomainFormPanelFinder(getDriver()).find();
+        domainFormPanel.manuallyDefineFields(extensibleCol);
         clickButton("Save");
     }
 


### PR DESCRIPTION
#### Rationale
WNPRC_EHRTest:
UTF characters don't tend to work correctly when used in Java string literals. Tests usually need to use the character code (e.g. `\u00BB` instead of `»`). I'm not sure why this test doesn't fail more regularly.

WNPRC_PurchasingTest:
Just need to wait for some elements.

#### Related Pull Requests
* N/A

#### Changes
* Use UTF character codes in `WNPRC_EHRTest`
* Fix timing in `WNPRC_PurchasingTest`
