### PR TITLE
Remove references to BuildUtils.getInternalProjectPath

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -55,12 +55,10 @@ dependencies {
     implementation 'org.jetbrains:annotations:15.0'
     implementation "junit:junit:${junitVersion}"
     implementation project(BuildUtils.getApiProjectPath(project.gradle))
-    implementation project(BuildUtils.getInternalProjectPath(project.gradle))
     implementation project(":server:modules:LabDevKitModules:LDK")
     implementation project(":server:modules:wnprc-modules:java2ts")
 }
 
-project.evaluationDependsOn(BuildUtils.getInternalProjectPath(project.gradle))
 project.evaluationDependsOn(BuildUtils.getApiProjectPath(project.gradle))
 
 tasks.jar {


### PR DESCRIPTION
#### Rationale
The guts of the internal module were moved elsewhere with [platform PR #4015](https://github.com/LabKey/platform/pull/4015).  Now we remove it entirely.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/166
* https://github.com/LabKey/server/pull/398

#### Changes
* Remove references to `BuildUtils.getInternalProjectPath`
