### PR TITLE
Fix WNPRC_PurchasingTest.testEmailCustomizationLineItemUpdate

### DIFF
--- a/DBUtils/api-src/org/labkey/dbutils/api/SimpleQueryUpdater.java
+++ b/DBUtils/api-src/org/labkey/dbutils/api/SimpleQueryUpdater.java
@@ -187,7 +187,12 @@ public class SimpleQueryUpdater {
     public List<Map<String, Object>> doUpdate(List<Map<String, Object>> rows) throws BatchValidationException , InvalidKeyException, SQLException, QueryUpdateServiceException {
         List<Map<String, Object>> updatedRows = new ArrayList<>();
         if (rows.size() > 0) {
-            updatedRows = service.updateRows(user, container, rows, rows, null, null);
+            BatchValidationException validationException = new BatchValidationException();
+            updatedRows = service.updateRows(user, container, rows, rows, validationException, null, null);
+
+            if (validationException.hasErrors()) {
+                throw validationException;
+            }
 
             if (updatedRows.size() != rows.size()) {
                 throw new QueryUpdateServiceException("Not all rows updated properly");
@@ -241,7 +246,7 @@ public class SimpleQueryUpdater {
 
     /**
      * Casts a "list" of rows to appropriate case insensitive rows for {@link QueryUpdateService#insertRows(User, Container, List, BatchValidationException, Map, Map)}
-     * and {@link QueryUpdateService#updateRows(User, Container, List, List, Map, Map)}.
+     * and {@link QueryUpdateService#updateRows(User, Container, List, List, BatchValidationException, Map, Map)}.
      *
      * @param rows A series (possibly of just one) of {@link Map<String, Object>} objects (which includes
      *             {@link JSONObject} objects, since they extend {@link Map<String, Object>}.

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
@@ -1009,7 +1009,10 @@ public class TriggerScriptHelper {
                 Container container = getContainer();
                 User user = getUser();
 
-                List<Map<String, Object>> updatedRows = genericTable.getUpdateService().updateRows(user, container, toUpdate, oldKeys, null, null);
+                BatchValidationException errors = new BatchValidationException();
+                List<Map<String, Object>> updatedRows = genericTable.getUpdateService().updateRows(user, container, toUpdate, oldKeys, errors, null, null);
+                if (errors.hasError())
+                    throw errors;
                 if (updatedRows.isEmpty()){
                     returnMessage = "Error changing QCState for waterAmount table";
 
@@ -1068,7 +1071,10 @@ public class TriggerScriptHelper {
                     Container container = getContainer();
                     User user = getUser();
                     Map<String, Object> context = getExtraContext();
-                    List<Map<String, Object>> updatedRows = waterTable.getUpdateService().updateRows(user, container, toUpdate, oldKeys, null, context);
+                    BatchValidationException errors = new BatchValidationException();
+                    List<Map<String, Object>> updatedRows = waterTable.getUpdateService().updateRows(user, container, toUpdate, oldKeys, errors, null, context);
+                    if (errors.hasErrors())
+                        throw errors;
                     if (!updatedRows.isEmpty())
                     {
                         completeWaterGivenTask(taskIds, waterTable);
@@ -1548,6 +1554,7 @@ public class TriggerScriptHelper {
                         if(!toUpdate.isEmpty()){
                             Container container = getContainer();
                             User user = getUser();
+                            BatchValidationException errors = new BatchValidationException();
                             List<Map<String, Object>> updateRows = waterOrders.getUpdateService().updateRows(user,container,toUpdate,oldKeys, null, null);
                             if (updateRows.isEmpty()){
                                 returnErrors.put("field", "Id");
@@ -1555,7 +1562,6 @@ public class TriggerScriptHelper {
                                 returnErrors.put("message", "Error closing Lixit/Ad Lib orders.");
 
                             }
-
                         }
                         insertRows(rowToAdd, "study", "waterScheduledAnimals");
                     }
@@ -2169,7 +2175,8 @@ public class TriggerScriptHelper {
                 {
                     Container container = getContainer();
                     User user = getUser();
-                    List<Map<String, Object>> updatedRows = waterOrders.getUpdateService().updateRows(user, container, toUpdate, oldKeys, null, null);
+                    BatchValidationException errors = new BatchValidationException();
+                    List<Map<String, Object>> updatedRows = waterOrders.getUpdateService().updateRows(user, container, toUpdate, oldKeys, errors, null, null);
                     if (updatedRows.isEmpty())
                     {
                         returnErrors.put("field", "project");

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
@@ -1011,7 +1011,7 @@ public class TriggerScriptHelper {
 
                 BatchValidationException errors = new BatchValidationException();
                 List<Map<String, Object>> updatedRows = genericTable.getUpdateService().updateRows(user, container, toUpdate, oldKeys, errors, null, null);
-                if (errors.hasError())
+                if (errors.hasErrors())
                     throw errors;
                 if (updatedRows.isEmpty()){
                     returnMessage = "Error changing QCState for waterAmount table";

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
@@ -1555,8 +1555,8 @@ public class TriggerScriptHelper {
                             Container container = getContainer();
                             User user = getUser();
                             BatchValidationException errors = new BatchValidationException();
-                            List<Map<String, Object>> updateRows = waterOrders.getUpdateService().updateRows(user,container,toUpdate,oldKeys, null, null);
-                            if (updateRows.isEmpty()){
+                            List<Map<String, Object>> updateRows = waterOrders.getUpdateService().updateRows(user,container,toUpdate,oldKeys, errors, null, null);
+                            if (updateRows.isEmpty() || errors.hasErrors()){
                                 returnErrors.put("field", "Id");
                                 returnErrors.put("severity", "ERROR");
                                 returnErrors.put("message", "Error closing Lixit/Ad Lib orders.");
@@ -2177,7 +2177,7 @@ public class TriggerScriptHelper {
                     User user = getUser();
                     BatchValidationException errors = new BatchValidationException();
                     List<Map<String, Object>> updatedRows = waterOrders.getUpdateService().updateRows(user, container, toUpdate, oldKeys, errors, null, null);
-                    if (updatedRows.isEmpty())
+                    if (errors.hasErrors() || updatedRows.isEmpty())
                     {
                         returnErrors.put("field", "project");
                         returnErrors.put("severity", "ERROR");

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
@@ -1633,7 +1633,10 @@ public class WNPRC_EHRController extends SpringActionController
 
                             service = ti.getUpdateService();
 
-                            List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, null, null);
+                            BatchValidationException errors = new BatchValidationException();
+                            List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, errors, null, null);
+                            if (errors.hasErrors())
+                                throw errors;
                             if (updatedRows.size() != rowToUpdate.size())
                             {
                                 throw new QueryUpdateServiceException("Not all rows updated properly");
@@ -1715,7 +1718,10 @@ public class WNPRC_EHRController extends SpringActionController
                         ti = QueryService.get().getUserSchema(getUser(), getContainer(), "study").getTable("waterOrders");
                         service = ti.getUpdateService();
 
-                        List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, null, extraContext);
+                        BatchValidationException errors = new BatchValidationException();
+                        List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, errors, null, extraContext);
+                        if (errors.hasErrors())
+                            throw errors;
                         if (updatedRows.size() != rowToUpdate.size())
                         {
                             throw new QueryUpdateServiceException("Not all rows updated properly");
@@ -1789,7 +1795,10 @@ public class WNPRC_EHRController extends SpringActionController
                         ti = QueryService.get().getUserSchema(getUser(), getContainer(), "study").getTable("waterOrders");
                         service = ti.getUpdateService();
 
-                        List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, null, null);
+                        BatchValidationException errors = new BatchValidationException();
+                        List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, errors, null, null);
+                        if (errors.hasErrors())
+                            throw errors;
                         if (updatedRows.size() != rowToUpdate.size())
                         {
                             throw new QueryUpdateServiceException("Not all rows updated properly");

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
@@ -1633,10 +1633,10 @@ public class WNPRC_EHRController extends SpringActionController
 
                             service = ti.getUpdateService();
 
-                            BatchValidationException errors = new BatchValidationException();
-                            List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, errors, null, null);
-                            if (errors.hasErrors())
-                                throw errors;
+                            BatchValidationException batchValidationException = new BatchValidationException();
+                            List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, batchValidationException, null, null);
+                            if (batchValidationException.hasErrors())
+                                throw batchValidationException;
                             if (updatedRows.size() != rowToUpdate.size())
                             {
                                 throw new QueryUpdateServiceException("Not all rows updated properly");
@@ -1718,10 +1718,10 @@ public class WNPRC_EHRController extends SpringActionController
                         ti = QueryService.get().getUserSchema(getUser(), getContainer(), "study").getTable("waterOrders");
                         service = ti.getUpdateService();
 
-                        BatchValidationException errors = new BatchValidationException();
-                        List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, errors, null, extraContext);
-                        if (errors.hasErrors())
-                            throw errors;
+                        BatchValidationException batchValidationException = new BatchValidationException();
+                        List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, batchValidationException, null, extraContext);
+                        if (batchValidationException.hasErrors())
+                            throw batchValidationException;
                         if (updatedRows.size() != rowToUpdate.size())
                         {
                             throw new QueryUpdateServiceException("Not all rows updated properly");
@@ -1795,9 +1795,9 @@ public class WNPRC_EHRController extends SpringActionController
                         ti = QueryService.get().getUserSchema(getUser(), getContainer(), "study").getTable("waterOrders");
                         service = ti.getUpdateService();
 
-                        BatchValidationException errors = new BatchValidationException();
-                        List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, errors, null, null);
-                        if (errors.hasErrors())
+                        BatchValidationException batchValidationException = new BatchValidationException();
+                        List<Map<String, Object>> updatedRows = service.updateRows(getUser(), getContainer(), rowToUpdate, rowToUpdate, batchValidationException, null, null);
+                        if (batchValidationException.hasErrors())
                             throw errors;
                         if (updatedRows.size() != rowToUpdate.size())
                         {
@@ -1859,10 +1859,6 @@ public class WNPRC_EHRController extends SpringActionController
                     if (taskToInsert.size() != insertedTask.size() || rowToInsert.size() != insertedRows.size()){
                         throw new QueryUpdateServiceException("Task record or water record not inserted");
                     }
-
-
-
-
 
                     transaction.commit();
                     //TODO: return JSON string with taskid and success

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
@@ -235,7 +235,7 @@ public class WNPRC_PurchasingManager
                 if (isNewRequest || requestForm.getIsReorder())
                     insertedPurchasingReq = qus.insertRows(user, container, purchasingRequestsData, errors, null, null);
                 else
-                    insertedPurchasingReq = qus.updateRows(user, container, purchasingRequestsData, null, null, null);
+                    insertedPurchasingReq = qus.updateRows(user, container, purchasingRequestsData, null, errors, null, null);
 
                 if (null != insertedPurchasingReq)
                     requestForm.setRowId((Integer) insertedPurchasingReq.get(0).get("rowId"));
@@ -326,7 +326,7 @@ public class WNPRC_PurchasingManager
                 if (newLineItemsData.size() > 0)
                     qus.insertRows(user, container, newLineItemsData, errors, null, null);
                 if (updatedLineItemsData.size() > 0)
-                    qus.updateRows(user, container, updatedLineItemsData, null, null, null);
+                    qus.updateRows(user, container, updatedLineItemsData, null, errors, null, null);
                 if (deleteLineItemsData.size() > 0)
                     qus.deleteRows(user, container, deleteLineItemsData, null, null);
             }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingUserSchema.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingUserSchema.java
@@ -4,10 +4,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.DatabaseTableType;
-import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
-import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.security.User;
 
 /**
@@ -60,24 +57,4 @@ public class WNPRC_PurchasingUserSchema extends SimpleUserSchema
         }
         return super.createTable(name, cf);
     }
-
-//    @Override
-//    public QueryUpdateService getUpdateService()
-//    {
-//        // UNDONE: add an 'isUserEditable' bit to the schema and table?
-//        if (!isReadOnly())
-//        {
-//            TableInfo table = getRealTable();
-//            if (table != null && table.getTableType() == DatabaseTableType.TABLE)
-//                return new SimpleQueryUpdateService(this, table)
-//                {
-//                    @Override
-//                    protected boolean supportUpdateUsingDIB()
-//                    {
-//                        return false;
-//                    }
-//                };
-//        }
-//        return null;
-//    }
 }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingUserSchema.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingUserSchema.java
@@ -61,23 +61,23 @@ public class WNPRC_PurchasingUserSchema extends SimpleUserSchema
         return super.createTable(name, cf);
     }
 
-    @Override
-    public QueryUpdateService getUpdateService()
-    {
-        // UNDONE: add an 'isUserEditable' bit to the schema and table?
-        if (!isReadOnly())
-        {
-            TableInfo table = getRealTable();
-            if (table != null && table.getTableType() == DatabaseTableType.TABLE)
-                return new SimpleQueryUpdateService(this, table)
-                {
-                    @Override
-                    protected boolean supportUpdateUsingDIB()
-                    {
-                        return false;
-                    }
-                };
-        }
-        return null;
-    }
+//    @Override
+//    public QueryUpdateService getUpdateService()
+//    {
+//        // UNDONE: add an 'isUserEditable' bit to the schema and table?
+//        if (!isReadOnly())
+//        {
+//            TableInfo table = getRealTable();
+//            if (table != null && table.getTableType() == DatabaseTableType.TABLE)
+//                return new SimpleQueryUpdateService(this, table)
+//                {
+//                    @Override
+//                    protected boolean supportUpdateUsingDIB()
+//                    {
+//                        return false;
+//                    }
+//                };
+//        }
+//        return null;
+//    }
 }

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingUserSchema.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingUserSchema.java
@@ -4,7 +4,10 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.DatabaseTableType;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.security.User;
 
 /**
@@ -56,5 +59,25 @@ public class WNPRC_PurchasingUserSchema extends SimpleUserSchema
             }
         }
         return super.createTable(name, cf);
+    }
+
+    @Override
+    public QueryUpdateService getUpdateService()
+    {
+        // UNDONE: add an 'isUserEditable' bit to the schema and table?
+        if (!isReadOnly())
+        {
+            TableInfo table = getRealTable();
+            if (table != null && table.getTableType() == DatabaseTableType.TABLE)
+                return new SimpleQueryUpdateService(this, table)
+                {
+                    @Override
+                    protected boolean supportUpdateUsingDIB()
+                    {
+                        return false;
+                    }
+                };
+        }
+        return null;
     }
 }


### PR DESCRIPTION
#### Rationale
ehr_purchasing.purchasingRequests has a custom query definition in wnprc_purchusing that adds special calculated columns. The email notifications sent are dependent on those calculated columns, which aren't returned by updateRows using prepared statement. This PR flag all ehr_purchasing tables to use the old row-by-row updates, instead of prepared statement.

TC failure:
https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_EhrPostgres/2274993?buildTab=tests&status=failed

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/529
* https://github.com/LabKey/wnprc-modules/pull/251

#### Changes
* update updateRows parameters to match updated signature
