### PR TITLE
Fix build for LDK/Laboratory API refactor

### DIFF
--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"))
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
     implementation project(path: "${project.parent.path}:DBUtils", configuration: "apiJarFile")
     implementation project(path: "${project.parent.path}:WebUtils", configuration: "apiJarFile")
     implementation project(path: "${project.parent.path}:GoogleDrive", configuration: "apiJarFile")

--- a/WNPRC_Purchasing/build.gradle
+++ b/WNPRC_Purchasing/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:EHR_Purchasing", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:EHR_Purchasing", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 }
 
 sourceSets {


### PR DESCRIPTION
#### Rationale
Related PRs moved LDK/Laboratory APIs from `platform` to `LabDevKeyModules`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4107
* https://github.com/LabKey/LabDevKitModules/pull/155