### PR TITLE
Create a new variant of wnprc-21.006-21.007.sql upgrade script so that it runs on recent servers

### DIFF
--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.001-22.002.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.001-22.002.sql
@@ -1,0 +1,7 @@
+-- wnprc-21.006-21.007.sql was added after wnprc-22.000-22.001.sql, in which case wnprc-21.006-21.007.sql would not run on some dev machines
+-- this script is a conditionalized version of what wnprc-21.006-21.007.sql intended to achieve
+alter table wnprc.animal_requests add column if not exists pregnantanimalsrequiredterminfant varchar(100);
+alter table wnprc.animal_requests add column if not exists pregnantanimalsrequiredtermdam varchar(100);
+alter table wnprc.animal_requests add column if not exists majorsurgery varchar(100);
+alter table wnprc.animal_requests add column if not exists previousexposures text;
+alter table wnprc.animal_requests add column if not exists contacts text;

--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.001-22.002.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.001-22.002.sql
@@ -1,5 +1,5 @@
 -- wnprc-21.006-21.007.sql was added after wnprc-22.000-22.001.sql, in which case wnprc-21.006-21.007.sql would not run on some dev machines
--- this script is a conditionalized version of what wnprc-21.006-21.007.sql intended to achieve
+-- this script is a correct conditionalized version of what wnprc-21.006-21.007.sql intended to achieve
 alter table wnprc.animal_requests add column if not exists pregnantanimalsrequiredterminfant varchar(100);
 alter table wnprc.animal_requests add column if not exists pregnantanimalsrequiredtermdam varchar(100);
 alter table wnprc.animal_requests add column if not exists majorsurgery varchar(100);

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -179,7 +179,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
 
     @Override
     public @Nullable Double getSchemaVersion() {
-        return forceUpdate ? Double.POSITIVE_INFINITY : 22.001;
+        return forceUpdate ? Double.POSITIVE_INFINITY : 22.002;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
wnprc-21.006-21.007.sql will not run on some recent servers since it was added after wnprc-22.000-22.001.sql, which bumped the module version to 22.001. This PR creates a new script wnprc-22.001-22.002.sql, which is a corrected conditionalized version of wnprc-21.006-21.007.sql.

#### Changes
* Add new script wnprc-22.001-22.002.sql (a corrected conditionalized version of wnprc-21.006-21.007.sql).
* Module version bump to 22.002.