### PR TITLE
Backport 22.00x upgrade scripts, bump schema version

### DIFF
--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.000-22.001.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.000-22.001.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS wnprc.session_log
+(
+    rowid                   serial NOT NULL,
+    start_time              TIMESTAMP,
+    end_time                TIMESTAMP,
+    schema_name             varchar(100),
+    query_name              varchar(100),
+    task_id                 varchar(255),
+    number_of_records       integer,
+    batch_add_used          boolean,
+    bulk_edit_used          boolean,
+    user_agent              varchar(255),
+    errors_occurred         boolean,
+    form_framework_type     integer,
+
+    -- Default fields for LabKey.
+    container         entityid NOT NULL,
+    createdby         userid,
+    created           TIMESTAMP,
+    modifiedby        userid,
+    modified          TIMESTAMP,
+
+    CONSTRAINT pk_session_log_rowid PRIMARY KEY (rowid),
+    CONSTRAINT fk_session_log_form_framework_type FOREIGN KEY (form_framework_type) REFERENCES ehr.form_framework_types (rowid)
+);
+

--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.001-22.002.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.001-22.002.sql
@@ -1,0 +1,7 @@
+-- wnprc-21.006-21.007.sql was added after wnprc-22.000-22.001.sql, in which case wnprc-21.006-21.007.sql would not run on some dev machines
+-- this script is a correct conditionalized version of what wnprc-21.006-21.007.sql intended to achieve
+alter table wnprc.animal_requests add column if not exists pregnantanimalsrequiredterminfant varchar(100);
+alter table wnprc.animal_requests add column if not exists pregnantanimalsrequiredtermdam varchar(100);
+alter table wnprc.animal_requests add column if not exists majorsurgery varchar(100);
+alter table wnprc.animal_requests add column if not exists previousexposures text;
+alter table wnprc.animal_requests add column if not exists contacts text;

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -179,7 +179,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
 
     @Override
     public @Nullable Double getSchemaVersion() {
-        return forceUpdate ? Double.POSITIVE_INFINITY : 21.007;
+        return forceUpdate ? Double.POSITIVE_INFINITY : 22.002;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Since there is active development in 21.11 release, update the release to have 22.00x upgrade scripts and schema bump so that when it gets merged forward, the scripts will run in order.

#### Related Pull Requests
* https://github.com/LabKey/wnprc-modules/pull/270

#### Changes
* Backport 22.00x upgrade scripts, bump schema version