### PR TITLE
Backport schema version bump

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -179,7 +179,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
 
     @Override
     public @Nullable Double getSchemaVersion() {
-        return forceUpdate ? Double.POSITIVE_INFINITY : 22.002;
+        return forceUpdate ? Double.POSITIVE_INFINITY : 22.007;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
This [PR](https://github.com/LabKey/wnprc-modules/pull/276) bumped the schema version to 22.007. Backporting to 21.11 so that new upgrade scripts can start numbering accordingly.

#### Changes
* Bump schema version
