### PR TITLE
New upgrade script with the contents of two different wnprc-22.001-21.002.sql scripts, and a schema version bump to 22.008

### DIFF
--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.007-22.008.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.007-22.008.sql
@@ -1,4 +1,4 @@
--- conditionalized version of wnprc-22.001-21.002.sql that got added in 22.11
+-- A conditionalized version of wnprc-22.001-21.002.sql that got added in 22.11
 DO $$
 BEGIN
 IF NOT EXISTS(SELECT *
@@ -24,7 +24,7 @@ END IF;
 END
 $$ LANGUAGE plpgsql;
 
--- conditionalized version of wnprc-21.006-21.007.sql (and wnprc-22.001-21.002.sql that was created in develop and backported to 21.11)
+-- A conditionalized version of wnprc-21.006-21.007.sql that was added as a new script 'wnprc-22.001-21.002.sql' in develop (and was backported to 21.11)
 alter table wnprc.animal_requests add column if not exists pregnantanimalsrequiredterminfant varchar(100);
 alter table wnprc.animal_requests add column if not exists pregnantanimalsrequiredtermdam varchar(100);
 alter table wnprc.animal_requests add column if not exists majorsurgery varchar(100);

--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.007-22.008.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.007-22.008.sql
@@ -1,0 +1,32 @@
+-- conditionalized version of wnprc-22.001-21.002.sql that got added in 22.11
+DO $$
+BEGIN
+IF NOT EXISTS(SELECT *
+    FROM information_schema.columns
+    WHERE table_name='animal_requests' and column_name='principalinvestigatorold')
+THEN
+    ALTER TABLE wnprc.animal_requests RENAME COLUMN principalinvestigator TO principalinvestigatorold;
+END IF;
+
+IF NOT EXISTS(SELECT *
+    FROM information_schema.columns
+    WHERE table_name='animal_requests' and column_name='principalinvestigator')
+THEN
+    ALTER TABLE wnprc.animal_requests ADD COLUMN principalinvestigator INTEGER;
+END IF;
+
+IF NOT EXISTS(SELECT *
+    FROM information_schema.constraint_column_usage
+    WHERE table_name='investigators' and lower(constraint_name) = 'fk_wnprc_animal_requests_ehr_investigators_rowid')
+THEN
+    ALTER TABLE wnprc.animal_requests ADD CONSTRAINT FK_WNPRC_ANIMAL_REQUESTS_EHR_INVESTIGATORS_ROWID FOREIGN KEY (principalinvestigator) REFERENCES ehr.investigators (rowid);
+END IF;
+END
+$$ LANGUAGE plpgsql;
+
+-- conditionalized version of wnprc-21.006-21.007.sql (and wnprc-22.001-21.002.sql that was created in develop and backported to 21.11)
+alter table wnprc.animal_requests add column if not exists pregnantanimalsrequiredterminfant varchar(100);
+alter table wnprc.animal_requests add column if not exists pregnantanimalsrequiredtermdam varchar(100);
+alter table wnprc.animal_requests add column if not exists majorsurgery varchar(100);
+alter table wnprc.animal_requests add column if not exists previousexposures text;
+alter table wnprc.animal_requests add column if not exists contacts text;

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -179,7 +179,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
 
     @Override
     public @Nullable Double getSchemaVersion() {
-        return forceUpdate ? Double.POSITIVE_INFINITY : 22.007;
+        return forceUpdate ? Double.POSITIVE_INFINITY : 22.008;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Add a new upgrade script 'wnprc-22.007-22.008.sql' with the contents of two different scripts with the same name 'wnprc-22.001-21.002.sql' - one was created in 22.11, and another in develop (and was backported to 21.11).

#### Changes
* Add a conditionalized version of wnprc-22.001-21.002.sql scripts.
* Schema version bump to 22.008 (from 22.007)