### PR TITLE
 Create a new script to drop NOT NULL constraint on principalinvestigatorold; Schema version bump to 22.009

### DIFF
--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.008-22.009.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.008-22.009.sql
@@ -1,0 +1,1 @@
+ALTER TABLE wnprc.animal_requests ALTER COLUMN principalinvestigatorold DROP NOT NULL;

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -179,7 +179,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
 
     @Override
     public @Nullable Double getSchemaVersion() {
-        return forceUpdate ? Double.POSITIVE_INFINITY : 22.008;
+        return forceUpdate ? Double.POSITIVE_INFINITY : 22.009;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Missed to include "principalinvestigatorold DROP NOT NULL;" when adding a new script in https://github.com/LabKey/wnprc-modules/pull/286

#### Changes
* Create a new script to include "principalinvestigatorold DROP NOT NULL;"
* Schema version bump to 22.009
