### PR TITLE
Use artifactory repos that don't proxy for third-party repos

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -1,7 +1,9 @@
 buildscript {
     repositories {
+        mavenCentral()
+        gradlePluginPortal()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {

--- a/gradle/settings/wnprc.gradle
+++ b/gradle/settings/wnprc.gradle
@@ -1,7 +1,9 @@
 buildscript {
     repositories {
+        mavenCentral()
+        gradlePluginPortal()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {


### PR DESCRIPTION
#### Rationale
When we proxy for third-party repos, many of the artifacts that are available from mavenCentral get cached in and served from our Artifactory instance.  We want to avoid this to reduce costs.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/461

#### Changes
* Use non-proxying repos
