### PR TITLE
22.11 fb generic build script for docker

### DIFF
--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -1,11 +1,11 @@
 # -----------------------------------------------------------------------------
 # HELPER IMAGE (to download LabKey)
-
+ARG LABKEY_VERSION
 FROM alpine:latest as download
 
 ARG LABKEY_TEAMCITY_PASSWORD
 ARG LABKEY_TEAMCITY_USERNAME
-ARG WNPRC_BRANCH=master
+ARG WNPRC_BRANCH=SNAPSHOT
 ARG LABKEY_VERSION
 
 WORKDIR /tmp/labkey
@@ -15,16 +15,17 @@ ARG LABKEY_TEAMCITY_BUILD=
 RUN apk update \
     && apk add --no-cache wget tar ca-certificates && update-ca-certificates
 
-RUN if [[ "$WNPRC_BRANCH" = "master" ] || ["$WNPRC_BRANCH" = "develop" ] ]; then B="" ; else B=",branch:"${WNPRC_BRANCH}; fi \
+RUN if [ "$WNPRC_BRANCH" = "SNAPSHOT" ] ; then B="" ; else B=",branch:"${WNPRC_BRANCH}; fi \
  && if [ "$WNPRC_BRANCH" = "develop" ] ; then \
-         echo -e "Building develop branch ";\
+        echo -e "Building develop branch "; \
+        B=""; \
         LABKEY_TEAMCITY_CONFIG="LabKey_Trunk_External_Wnprc_Installers_2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
         LABKEY_DISTRIBUTION="wisc" ; \
         LABKEY_FILE_NAME="UWisc.tar.gz" ; \
     else  \
-         echo -e "LabKey Version: " ${LABKEY_VERSION}; \
-         echo -e "Branch: " ${$WNPRC_BRANCH}; \
+        echo -e "LabKey Version: " ${LABKEY_VERSION}; \
+        echo -e "Branch: " ${WNPRC_BRANCH}; \
         GENERAL_LK_VERSION=${LABKEY_VERSION//./}; \
         LABKEY_TEAMCITY_CONFIG="LabKey_${GENERAL_LK_VERSION}Release_External_Wnprc_Installers2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
@@ -42,8 +43,7 @@ RUN if [[ "$WNPRC_BRANCH" = "master" ] || ["$WNPRC_BRANCH" = "develop" ] ]; then
 
 # -----------------------------------------------------------------------------
 # MAIN IMAGE BUILD DEFINITION
-
-FROM wnprcehr/tomcat:tomcat9_22.7
+FROM wnprcehr/tomcat:tomcat9_${LABKEY_VERSION}
 
 # copy in LabKey from the other stage of the build and copy in the jars to tomcat
 ENV LABKEY_HOME /usr/local/labkey

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # HELPER IMAGE (to download LabKey)
 ARG LABKEY_VERSION
-ARG WNPRC_BRANCH
+ARG TOMCAT_IMAGE
 FROM alpine:latest as download
 
 ARG LABKEY_TEAMCITY_PASSWORD
@@ -44,7 +44,7 @@ RUN if [ "$WNPRC_BRANCH" = "SNAPSHOT" ] ; then B="" ; else B=",branch:"${WNPRC_B
 
 # -----------------------------------------------------------------------------
 # MAIN IMAGE BUILD DEFINITION
-FROM wnprcehr/tomcat:tomcat9_${LABKEY_VERSION}_${WNPRC_BRANCH}
+FROM wnprcehr/tomcat:tomcat9_${LABKEY_VERSION}${TOMCAT_IMAGE}
 
 # copy in LabKey from the other stage of the build and copy in the jars to tomcat
 ENV LABKEY_HOME /usr/local/labkey

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -1,11 +1,12 @@
 # -----------------------------------------------------------------------------
 # HELPER IMAGE (to download LabKey)
 ARG LABKEY_VERSION
+ARG WNPRC_BRANCH
 FROM alpine:latest as download
 
 ARG LABKEY_TEAMCITY_PASSWORD
 ARG LABKEY_TEAMCITY_USERNAME
-ARG WNPRC_BRANCH=SNAPSHOT
+ARG WNPRC_BRANCH
 ARG LABKEY_VERSION
 
 WORKDIR /tmp/labkey
@@ -43,7 +44,7 @@ RUN if [ "$WNPRC_BRANCH" = "SNAPSHOT" ] ; then B="" ; else B=",branch:"${WNPRC_B
 
 # -----------------------------------------------------------------------------
 # MAIN IMAGE BUILD DEFINITION
-FROM wnprcehr/tomcat:tomcat9_${LABKEY_VERSION}
+FROM wnprcehr/tomcat:tomcat9_${LABKEY_VERSION}_${WNPRC_BRANCH}
 
 # copy in LabKey from the other stage of the build and copy in the jars to tomcat
 ENV LABKEY_HOME /usr/local/labkey

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -7,7 +7,6 @@ ARG LABKEY_TEAMCITY_PASSWORD
 ARG LABKEY_TEAMCITY_USERNAME
 ARG WNPRC_BRANCH=master
 ARG LABKEY_VERSION
-ARG LABKEY_IS_PREMIUM=true
 
 WORKDIR /tmp/labkey
 
@@ -16,25 +15,16 @@ ARG LABKEY_TEAMCITY_BUILD=
 RUN apk update \
     && apk add --no-cache wget tar ca-certificates && update-ca-certificates
 
-RUN if [ "$WNPRC_BRANCH" = "master" ] ; then B="" ; else B=",branch:"${WNPRC_BRANCH}; fi \
- && if [ -z "$LABKEY_VERSION" ] ; then \
-         echo -e "No LabKey version, building trunk ";\
+RUN if [[ "$WNPRC_BRANCH" = "master" ] || ["$WNPRC_BRANCH" = "develop" ] ]; then B="" ; else B=",branch:"${WNPRC_BRANCH}; fi \
+ && if [ "$WNPRC_BRANCH" = "develop" ] ; then \
+         echo -e "Building develop branch ";\
         LABKEY_TEAMCITY_CONFIG="LabKey_Trunk_External_Wnprc_Installers_2" ; \
-        LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
-        LABKEY_DISTRIBUTION="wisc" ; \
-        LABKEY_FILE_NAME="UWisc.tar.gz" ; \
-    elif [ "$LABKEY_VERSION" = 21.7 ] ; then \
-        LABKEY_TEAMCITY_CONFIG="LabKey_217Release_External_Wnprc_Installers" ; \
-        LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
-        LABKEY_DISTRIBUTION="wisc" ; \
-        LABKEY_FILE_NAME="UWisc.tar.gz" ; \
-    elif [ "$LABKEY_VERSION" = 21.11 ] ; then \
-        LABKEY_TEAMCITY_CONFIG="LabKey_2111Release_External_Wnprc_Installers2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
         LABKEY_DISTRIBUTION="wisc" ; \
         LABKEY_FILE_NAME="UWisc.tar.gz" ; \
     else  \
          echo -e "LabKey Version: " ${LABKEY_VERSION}; \
+         echo -e "Branch: " ${$WNPRC_BRANCH}; \
         GENERAL_LK_VERSION=${LABKEY_VERSION//./}; \
         LABKEY_TEAMCITY_CONFIG="LabKey_${GENERAL_LK_VERSION}Release_External_Wnprc_Installers2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \

--- a/docker/labkey/hooks/build
+++ b/docker/labkey/hooks/build
@@ -13,22 +13,30 @@ if [[ $DOCKER_TAG =~ $DEVBRANCH ]]
 then
     LK_VERSION=${BASH_REMATCH[1]}
     SHORT_BRANCH_NAME=$DEVBRANCH
+
+    docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
 #Docker tag for SNAPSHOT and FB
 elif [[ $DOCKER_TAG =~ $FB_REGEX  ]]
 then
     LK_VERSION=${BASH_REMATCH[1]}
     SHORT_BRANCH_NAME=${BASH_REMATCH[2]}
+
+    docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
 elif [[ $DOCKER_TAG =~ $PROD_REGEX ]]
 then
     LK_VERSION=${BASH_REMATCH[1]}
     SHORT_BRANCH_NAME="master"
+
+    # Some debugging info
+echo "LabKey version: $LK_VERSION"
+echo "Branch name: $SHORT_BRANCH_NAME"
+
+    docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
 else
     echo "ERROR: DOCKER_TAG ($DOCKER_TAG) did not match the pattern of a feature branch or a production branch"
     exit 1
 fi
 
-# Some debugging info
-echo "LabKey version: $LK_VERSION"
-echo "Branch name: $SHORT_BRANCH_NAME"
 
-docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
+
+

--- a/docker/labkey/hooks/build
+++ b/docker/labkey/hooks/build
@@ -13,17 +13,20 @@ if [[ $DOCKER_TAG =~ $DEVBRANCH_REGEX ]]
 then
     LK_VERSION=${BASH_REMATCH[1]}
     SHORT_BRANCH_NAME="develop"
+    TOMCAT_IMAGE="_develop"
 
 elif [[ $DOCKER_TAG =~ $PROD_REGEX ]]
 then
     LK_VERSION=${BASH_REMATCH[1]}
     SHORT_BRANCH_NAME="SNAPSHOT"
+    TOMCAT_IMAGE=""
 
 #Docker tag for SNAPSHOT and FB
 elif [[ $DOCKER_TAG =~ $FB_REGEX  ]]
 then
     LK_VERSION=${BASH_REMATCH[1]}
     SHORT_BRANCH_NAME=${BASH_REMATCH[2]}
+    TOMCAT_IMAGE="_${SHORT_BRANCH_NAME}"
     
 else
     echo "ERROR: DOCKER_TAG ($DOCKER_TAG) did not match the pattern of a feature branch or a production branch"
@@ -34,8 +37,4 @@ fi
 echo "LabKey version: $LK_VERSION"
 echo "Branch name: $SHORT_BRANCH_NAME"
 
-docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
-
-
-
-
+docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg TOMCAT_IMAGE=$TOMCAT_IMAGE --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .

--- a/docker/labkey/hooks/build
+++ b/docker/labkey/hooks/build
@@ -3,16 +3,16 @@ echo "build ver 1.4"
 
 # FB_REGEX will match if the docker tag looks like a feature branch, while
 # PROD_REGEX will match if the docker tag matches the format of a production build
-DEVBRANCH="develop"
+DEVBRANCH_REGEX="^([0-9]{2}\.[0-9]{1,2})_refs_heads_develop"
 FB_REGEX="^([0-9]{2}\.[0-9]{1,2})_(.*)"
 PROD_REGEX=${BASH_REMATCH[1]}
 
 LK_VERSION=""
 
-if [[ $DOCKER_TAG =~ $DEVBRANCH ]]
+if [[ $DOCKER_TAG =~ $DEVBRANCH_REGEX ]]
 then
     LK_VERSION=${BASH_REMATCH[1]}
-    SHORT_BRANCH_NAME=$DEVBRANCH
+    SHORT_BRANCH_NAME="develop"
 
     echo "LabKey version: $LK_VERSION"
     echo "Branch name: $SHORT_BRANCH_NAME"

--- a/docker/labkey/hooks/build
+++ b/docker/labkey/hooks/build
@@ -5,7 +5,7 @@ echo "build ver 1.4"
 # PROD_REGEX will match if the docker tag matches the format of a production build
 DEVBRANCH="develop"
 FB_REGEX="^([0-9]{2}\.[0-9]{1,2})_(.*)"
-PROD_REGEX="release([0-9]{2}\.[0-9]{1,2})-SNAPSHOT"
+PROD_REGEX=${BASH_REMATCH[1]}
 
 LK_VERSION=""
 
@@ -16,7 +16,7 @@ then
 
     echo "LabKey version: $LK_VERSION"
     echo "Branch name: $SHORT_BRANCH_NAME"
-    
+
     docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
 #Docker tag for SNAPSHOT and FB
 elif [[ $DOCKER_TAG =~ $FB_REGEX  ]]

--- a/docker/labkey/hooks/build
+++ b/docker/labkey/hooks/build
@@ -14,12 +14,18 @@ then
     LK_VERSION=${BASH_REMATCH[1]}
     SHORT_BRANCH_NAME=$DEVBRANCH
 
+    echo "LabKey version: $LK_VERSION"
+    echo "Branch name: $SHORT_BRANCH_NAME"
+    
     docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
 #Docker tag for SNAPSHOT and FB
 elif [[ $DOCKER_TAG =~ $FB_REGEX  ]]
 then
     LK_VERSION=${BASH_REMATCH[1]}
     SHORT_BRANCH_NAME=${BASH_REMATCH[2]}
+    
+    echo "LabKey version: $LK_VERSION"
+    echo "Branch name: $SHORT_BRANCH_NAME"
 
     docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
 elif [[ $DOCKER_TAG =~ $PROD_REGEX ]]
@@ -28,8 +34,8 @@ then
     SHORT_BRANCH_NAME="master"
 
     # Some debugging info
-echo "LabKey version: $LK_VERSION"
-echo "Branch name: $SHORT_BRANCH_NAME"
+    echo "LabKey version: $LK_VERSION"
+    echo "Branch name: $SHORT_BRANCH_NAME"
 
     docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
 else

--- a/docker/labkey/hooks/build
+++ b/docker/labkey/hooks/build
@@ -1,11 +1,11 @@
 #!/bin/bash
-echo "build ver 1.4"
+echo "build ver 1.5"
 
 # FB_REGEX will match if the docker tag looks like a feature branch, while
 # PROD_REGEX will match if the docker tag matches the format of a production build
 DEVBRANCH_REGEX="^([0-9]{2}\.[0-9]{1,2})_refs_heads_develop"
 FB_REGEX="^([0-9]{2}\.[0-9]{1,2})_(.*)"
-PROD_REGEX=${BASH_REMATCH[1]}
+PROD_REGEX="^([0-9]{2}\.[0-9]{1,2})_refs_heads_release([0-9]{2}\.[0-9]{1,2})-SNAPSHOT"
 
 LK_VERSION=""
 
@@ -14,34 +14,27 @@ then
     LK_VERSION=${BASH_REMATCH[1]}
     SHORT_BRANCH_NAME="develop"
 
-    echo "LabKey version: $LK_VERSION"
-    echo "Branch name: $SHORT_BRANCH_NAME"
+elif [[ $DOCKER_TAG =~ $PROD_REGEX ]]
+then
+    LK_VERSION=${BASH_REMATCH[1]}
+    SHORT_BRANCH_NAME="SNAPSHOT"
 
-    docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
 #Docker tag for SNAPSHOT and FB
 elif [[ $DOCKER_TAG =~ $FB_REGEX  ]]
 then
     LK_VERSION=${BASH_REMATCH[1]}
     SHORT_BRANCH_NAME=${BASH_REMATCH[2]}
     
-    echo "LabKey version: $LK_VERSION"
-    echo "Branch name: $SHORT_BRANCH_NAME"
-
-    docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
-elif [[ $DOCKER_TAG =~ $PROD_REGEX ]]
-then
-    LK_VERSION=${BASH_REMATCH[1]}
-    SHORT_BRANCH_NAME="master"
-
-    # Some debugging info
-    echo "LabKey version: $LK_VERSION"
-    echo "Branch name: $SHORT_BRANCH_NAME"
-
-    docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
 else
     echo "ERROR: DOCKER_TAG ($DOCKER_TAG) did not match the pattern of a feature branch or a production branch"
     exit 1
 fi
+
+# Some debugging info
+echo "LabKey version: $LK_VERSION"
+echo "Branch name: $SHORT_BRANCH_NAME"
+
+docker build --build-arg LABKEY_TEAMCITY_USERNAME=$teamcityUser --build-arg LABKEY_TEAMCITY_PASSWORD=$teamCityPWD --build-arg WNPRC_BRANCH=$SHORT_BRANCH_NAME --build-arg LABKEY_VERSION=$LK_VERSION --rm=true -t $IMAGE_NAME .
 
 
 

--- a/docker/labkey/hooks/post_push
+++ b/docker/labkey/hooks/post_push
@@ -2,6 +2,33 @@
 
 GIT_HUB_TAG="docker/$DOCKER_TAG"
 
+WNPRC_REPO="wnprcehr/labkey"
+LK_VERSION=""
+
+PROD_REGEX="^([0-9]{2}\.[0-9]{1,2})_refs_heads_release([0-9]{2}\.[0-9]{1,2})-SNAPSHOT"
+FB_REGEX="^([0-9]{2}\.[0-9]{1,2})_(.*)"
+
 echo "Deleting following tag: $GIT_HUB_TAG"
+
+if [[ $DOCKER_TAG =~ $PROD_REGEX ]]
+then
+    echo "Pushing image to SNAPSHOT repo, version " ${BASH_REMATCH[1]}
+    #WNPRC_REPO+=snapshot
+    docker tag $IMAGE_NAME "wnprcehr/labkeysnapshot:"${BASH_REMATCH[1]}_${DOCKER_TAG}
+    docker push "wnprcehr/labkeysnapshot":${BASH_REMATCH[1]}
+
+elif [[ $DOCKER_TAG =~ $FB_REGEX  ]]
+then
+    docker tag $IMAGE_NAME "wnprcehr/labkey:"${BASH_REMATCH[1]}_${DOCKER_TAG}
+    docker push "wnprcehr/labkey:"${BASH_REMATCH[1]}_${DOCKER_TAG}
+
+else
+    echo "Pushing develop branch"
+    docker push "wnprcehr/labkey:"${BASH_REMATCH[1]}_develop
+
+fi
+
+#docker tag $IMAGE_NAME $WNPRC_REPO:${BASH_REMATCH[1]}_${DOCKER_TAG}
+#docker push $WNPRC_REPO:${BASH_REMATCH[1]}
 
 git push --delete origin $GIT_HUB_TAG

--- a/docker/labkey/hooks/post_push
+++ b/docker/labkey/hooks/post_push
@@ -8,8 +8,6 @@ LK_VERSION=""
 PROD_REGEX="^([0-9]{2}\.[0-9]{1,2})_refs_heads_release([0-9]{2}\.[0-9]{1,2})-SNAPSHOT"
 FB_REGEX="^([0-9]{2}\.[0-9]{1,2})_(.*)"
 
-echo "Deleting following tag: $GIT_HUB_TAG"
-
 if [[ $DOCKER_TAG =~ $PROD_REGEX ]]
 then
     echo "Pushing image to SNAPSHOT repo, version " ${BASH_REMATCH[1]}
@@ -33,4 +31,5 @@ fi
 #docker tag $IMAGE_NAME $WNPRC_REPO:${BASH_REMATCH[1]}_${DOCKER_TAG}
 #docker push $WNPRC_REPO:${BASH_REMATCH[1]}
 
+echo "Deleting following tag: $GIT_HUB_TAG"
 git push --delete origin $GIT_HUB_TAG

--- a/docker/labkey/hooks/post_push
+++ b/docker/labkey/hooks/post_push
@@ -14,16 +14,17 @@ if [[ $DOCKER_TAG =~ $PROD_REGEX ]]
 then
     echo "Pushing image to SNAPSHOT repo, version " ${BASH_REMATCH[1]}
     #WNPRC_REPO+=snapshot
-    docker tag $IMAGE_NAME "wnprcehr/labkeysnapshot:"${BASH_REMATCH[1]}_${DOCKER_TAG}
+    docker tag $IMAGE_NAME "wnprcehr/labkeysnapshot:"${BASH_REMATCH[1]}
     docker push "wnprcehr/labkeysnapshot":${BASH_REMATCH[1]}
 
 elif [[ $DOCKER_TAG =~ $FB_REGEX  ]]
 then
-    docker tag $IMAGE_NAME "wnprcehr/labkey:"${BASH_REMATCH[1]}_${DOCKER_TAG}
-    docker push "wnprcehr/labkey:"${BASH_REMATCH[1]}_${DOCKER_TAG}
+    docker tag $IMAGE_NAME "wnprcehr/labkey:"${BASH_REMATCH[1]}_${BASH_REMATCH[2]}
+    docker push "wnprcehr/labkey:"${BASH_REMATCH[1]}_${BASH_REMATCH[2]}
 
 else
     echo "Pushing develop branch"
+    docker tag $IMAGE_NAME "wnprcehr/labkey:"${BASH_REMATCH[1]}_develop
     docker push "wnprcehr/labkey:"${BASH_REMATCH[1]}_develop
 
 fi

--- a/docker/labkey/hooks/post_push
+++ b/docker/labkey/hooks/post_push
@@ -19,6 +19,7 @@ then
 
 elif [[ $DOCKER_TAG =~ $FB_REGEX  ]]
 then
+    echo "Push image to Docker repo ${WNPRC_REPPO} with tag ${BASH_REMATCH[1]}_${BASH_REMATCH[2]}"
     docker tag $IMAGE_NAME "wnprcehr/labkey:"${BASH_REMATCH[1]}_${BASH_REMATCH[2]}
     docker push "wnprcehr/labkey:"${BASH_REMATCH[1]}_${BASH_REMATCH[2]}
 


### PR DESCRIPTION
#### Rationale
This change will make Docker hub pick any future version of LabKey from GitHub without needing to add the specific version number.

#### Related Pull Requests
none

#### Changes
- adding support for SNAPSHOT branches
- improving build command for Docker Hub
- Improving post_push command to send SNAPSHOT images to different repos.
