### PR TITLE
Fix for virology results upload ext bug

### DIFF
--- a/WNPRC_EHR/resources/referenceStudy/study/datasets/datasets_metadata.xml
+++ b/WNPRC_EHR/resources/referenceStudy/study/datasets/datasets_metadata.xml
@@ -4143,82 +4143,129 @@
         <columnTitle>Id</columnTitle>
         <description>Subject identifier</description>
         <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+        <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
         <nullable>false</nullable>
+        <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+        <importAliases>
+          <importAlias>ptid</importAlias>
+          <importAlias>participantid</importAlias>
+        </importAliases>
         <fk>
           <fkDbSchema>study</fkDbSchema>
           <fkTable>Animal</fkTable>
           <fkColumnName>Id</fkColumnName>
         </fk>
+        <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+        <scale>32</scale>
       </column>
       <column columnName="date">
         <datatype>timestamp</datatype>
         <columnTitle>Date</columnTitle>
         <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+        <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
         <nullable>false</nullable>
+        <formatString>Date</formatString>
       </column>
       <column columnName="seq">
         <datatype>integer</datatype>
         <columnTitle>Seq</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#int</rangeURI>
         <isHidden>true</isHidden>
       </column>
       <column columnName="source">
         <datatype>varchar</datatype>
-        <columnTitle>Source</columnTitle>
+        <columnTitle>Sample Type</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <dimension>false</dimension>
+        <fk>
+          <fkDbSchema>ehr_lookups</fkDbSchema>
+          <fkTable>clinpath_sampletype</fkTable>
+          <fkColumnName>value</fkColumnName>
+        </fk>
+        <scale>0</scale>
       </column>
       <column columnName="result">
         <datatype>varchar</datatype>
         <columnTitle>Result</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <scale>0</scale>
       </column>
       <column columnName="virus">
         <datatype>varchar</datatype>
         <columnTitle>Virus</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <dimension>false</dimension>
+        <fk>
+          <fkDbSchema>ehr_lookups</fkDbSchema>
+          <fkTable>virology_tests</fkTable>
+          <fkColumnName>testid</fkColumnName>
+        </fk>
+        <scale>0</scale>
       </column>
       <column columnName="method">
         <datatype>varchar</datatype>
         <columnTitle>Method</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <dimension>false</dimension>
+        <fk>
+          <fkDbSchema>ehr_lookups</fkDbSchema>
+          <fkTable>virology_method</fkTable>
+          <fkColumnName>value</fkColumnName>
+        </fk>
+        <scale>0</scale>
       </column>
       <column columnName="remark">
         <datatype>varchar</datatype>
         <inputType>textarea</inputType>
         <columnTitle>Remark</columnTitle>
         <propertyURI>urn:ehr.labkey.org/#Remark</propertyURI>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#multiLine</rangeURI>
+        <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+        <scale>-1</scale>
       </column>
-      <column columnName="Description">
+      <column columnName="description">
         <datatype>varchar</datatype>
         <inputType>textarea</inputType>
         <columnTitle>Description</columnTitle>
-        <propertyURI>urn:ehr.labkey.org/#Description</propertyURI>
-        <isHidden>true</isHidden>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#multiLine</rangeURI>
         <shownInInsertView>false</shownInInsertView>
         <shownInUpdateView>false</shownInUpdateView>
         <shownInDetailsView>false</shownInDetailsView>
+        <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+        <scale>4000</scale>
       </column>
       <column columnName="objectid">
         <datatype>entityid</datatype>
         <columnTitle>Key</columnTitle>
         <propertyURI>urn:ehr.labkey.org/#ObjectId</propertyURI>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
         <isHidden>true</isHidden>
         <shownInInsertView>false</shownInInsertView>
         <shownInUpdateView>false</shownInUpdateView>
         <shownInDetailsView>false</shownInDetailsView>
+        <scale>100</scale>
         <isKeyField>true</isKeyField>
       </column>
-      <column columnName="parentId">
+      <column columnName="parentid">
         <datatype>varchar</datatype>
-        <columnTitle>Parent Id</columnTitle>
+        <columnTitle>Encounter Id</columnTitle>
         <propertyURI>urn:ehr.labkey.org/#ParentId</propertyURI>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
         <isHidden>true</isHidden>
-        <shownInInsertView>false</shownInInsertView>
         <shownInUpdateView>false</shownInUpdateView>
         <shownInDetailsView>false</shownInDetailsView>
+        <fk>
+          <fkDbSchema>study</fkDbSchema>
+          <fkTable>encounters</fkTable>
+          <fkColumnName>objectid</fkColumnName>
+        </fk>
+        <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+        <scale>400</scale>
       </column>
-      <column columnName="runId">
-        <datatype>varchar</datatype>
-        <columnTitle>Run Id</columnTitle>
-      </column>	  
       <column columnName="ts">
         <datatype>timestamp</datatype>
         <columnTitle>Last Changed</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#dateTime</rangeURI>
         <isHidden>true</isHidden>
         <shownInInsertView>false</shownInInsertView>
         <shownInUpdateView>false</shownInUpdateView>
@@ -4226,57 +4273,125 @@
       </column>
       <column columnName="taskid">
         <datatype>varchar</datatype>
-        <columnTitle>Taskid</columnTitle>
+        <columnTitle>Task Id</columnTitle>
         <propertyURI>urn:ehr.labkey.org/#TaskId</propertyURI>
-        <isHidden>true</isHidden>
-        <shownInInsertView>false</shownInInsertView>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
         <shownInUpdateView>false</shownInUpdateView>
         <shownInDetailsView>false</shownInDetailsView>
+        <dimension>false</dimension>
+        <url replaceMissing="blankValue"><![CDATA[/ehr/taskDetails.view?formtype=${taskid/formtype}&taskid=${taskid}]]></url>
+        <fk>
+          <fkDbSchema>ehr</fkDbSchema>
+          <fkTable>tasks</fkTable>
+          <fkColumnName>taskid</fkColumnName>
+        </fk>
+        <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+        <scale>100</scale>
       </column>
       <column columnName="project">
         <datatype>integer</datatype>
         <columnTitle>Project</columnTitle>
         <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
-        <importAliases>
-          <importAlias>pno</importAlias>
-        </importAliases>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#int</rangeURI>
+        <dimension>false</dimension>
+        <measure>true</measure>
         <formatString>00000000</formatString>
+        <fk>
+          <fkDbSchema>ehr</fkDbSchema>
+          <fkTable>project</fkTable>
+          <fkColumnName>project</fkColumnName>
+        </fk>
       </column>
       <column columnName="account">
         <datatype>varchar</datatype>
         <columnTitle>Account</columnTitle>
         <propertyURI>urn:ehr.labkey.org/#Account</propertyURI>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <scale>4000</scale>
       </column>
       <column columnName="performedby">
         <datatype>varchar</datatype>
         <columnTitle>Performed By</columnTitle>
         <propertyURI>urn:ehr.labkey.org/#PerformedBy</propertyURI>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <scale>64</scale>
       </column>
       <column columnName="requestid">
         <datatype>varchar</datatype>
-        <columnTitle>Requestid</columnTitle>
+        <columnTitle>Request Id</columnTitle>
         <propertyURI>urn:ehr.labkey.org/#RequestId</propertyURI>
-        <isHidden>true</isHidden>
-        <shownInInsertView>false</shownInInsertView>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
         <shownInUpdateView>false</shownInUpdateView>
         <shownInDetailsView>false</shownInDetailsView>
+        <dimension>false</dimension>
+        <url replaceMissing="blankValue"><![CDATA[/ehr/requestDetails.view?formtype=${requestid/formtype}&requestid=${requestid}]]></url>
+        <fk>
+          <fkDbSchema>ehr</fkDbSchema>
+          <fkTable>requests</fkTable>
+          <fkColumnName>requestid</fkColumnName>
+        </fk>
+        <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+        <scale>100</scale>
       </column>
       <column columnName="enddate">
         <datatype>timestamp</datatype>
-        <columnTitle>Enddate</columnTitle>
+        <columnTitle>End Date</columnTitle>
         <propertyURI>urn:ehr.labkey.org/#EndDate</propertyURI>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#dateTime</rangeURI>
         <isHidden>true</isHidden>
+        <formatString>DateTime</formatString>
       </column>
       <column columnName="units">
         <datatype>varchar</datatype>
         <columnTitle>Units</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <defaultValueType>FIXED_EDITABLE</defaultValueType>
+        <scale>0</scale>
       </column>
-      <column columnName="qualResult">
+      <column columnName="qualresult">
         <datatype>varchar</datatype>
-        <columnTitle>Qual Result</columnTitle>
+        <columnTitle>Qualifier</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <dimension>false</dimension>
+        <fk>
+          <fkDbSchema>ehr_lookups</fkDbSchema>
+          <fkTable>qualitative_results</fkTable>
+          <fkColumnName>result</fkColumnName>
+        </fk>
+        <defaultValueType>FIXED_EDITABLE</defaultValueType>
+        <scale>0</scale>
+      </column>
+      <column columnName="performing_lab">
+        <datatype>varchar</datatype>
+        <columnTitle>Performing Lab</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <fk>
+          <fkDbSchema>wnprc</fkDbSchema>
+          <fkTable>external_labs</fkTable>
+          <fkColumnName>code</fkColumnName>
+        </fk>
+        <defaultValueType>FIXED_EDITABLE</defaultValueType>
+        <scale>4000</scale>
       </column>
     </columns>
     <tableTitle>Virology Results</tableTitle>
+    <indices>
+      <index type="non-unique">
+        <column>taskid</column>
+      </index>
+      <index type="non-unique">
+        <column>objectid</column>
+      </index>
+      <index type="non-unique">
+        <column>parentid</column>
+      </index>
+      <index type="non-unique">
+        <column>requestid</column>
+      </index>
+      <index type="non-unique">
+        <column>participantsequencenum</column>
+      </index>
+    </indices>
   </table>
   <table tableName="arrival" tableDbType="TABLE">
     <description>Arrival of animals at WNPRC</description>

--- a/WNPRC_EHR/resources/web/ehr/ext3/ehrGridFormPanel.js
+++ b/WNPRC_EHR/resources/web/ehr/ext3/ehrGridFormPanel.js
@@ -1227,7 +1227,7 @@ EHR.ext.GridFormPanel = Ext.extend(Ext.Panel,
                                                         matchingFound = true;
                                                         virologyResults.addRecord({
                                                             Id:             resultRow['Id'],
-                                                            date:           resultRow['Date'].replace(/-/g, '/'),
+                                                            date:           resultRow['Date'],
                                                             virus:          resultRow['Virus'],
                                                             method:         resultRow['Method'],
                                                             result:         resultRow['Result'],

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -72,6 +72,7 @@ import org.openqa.selenium.support.ui.Select;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -157,7 +158,12 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
     protected static final String ROOM_ID_EHR_TEST = "2341092";
     protected static final String[] ANIMAL_SUBSET_EHR_TEST = {"test3844307", "test8976544", "test9195996"};
 
+    //Note: if updating this file, also update VIROLOGY_RESULT_DATA variable to match it, that way we can test
+    // the api end point which converts xlsx to JSON as well as the frontend extJS after it gets uploaded.
     private static final String CORRECT_SAMPLE_FILE_NAME = "virologyResults_correct.xlsx";
+    private static final Map<String, Object> VIROLOGY_RESULT_DATA = new HashMap<>();
+    //shortcut to getting the file content in the xlsx file.
+
     private static final String INCORRECT_FORMAT_SAMPLE_FILE_NAME = "virologyResults_baddate.xlsx";
     private static final String NO_MATCHING_RECORDS_SAMPLE_FILE_NAME = "virologyResults_nomatch.xlsx";
     private static final File CORRECT_SAMPLE_FILE = TestFileUtils.getSampleData("wnprc_ehr/clinpath/" + CORRECT_SAMPLE_FILE_NAME);
@@ -475,6 +481,17 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         _fileBrowserHelper.uploadFile(CORRECT_SAMPLE_FILE);
         _fileBrowserHelper.uploadFile(INCORRECT_FORMAT_SAMPLE_FILE);
         _fileBrowserHelper.uploadFile(NO_MATCHING_RECORDS_SAMPLE_FILE);
+
+        // set up the viral load hashmap to match CORRECT_SAMPLE_FILE
+        VIROLOGY_RESULT_DATA.put("Id", "test1993532");
+        VIROLOGY_RESULT_DATA.put("Date", "2022-07-22");
+        VIROLOGY_RESULT_DATA.put("Sample Type", "Blood - EDTA Whole Blood");
+        VIROLOGY_RESULT_DATA.put("Virus", "SRV 1,2,3,4,5");
+        VIROLOGY_RESULT_DATA.put("Method", "PCR");
+        VIROLOGY_RESULT_DATA.put("Result", "-");
+        VIROLOGY_RESULT_DATA.put("Qualifier", "Negative");
+        VIROLOGY_RESULT_DATA.put("Remark", "CRL");
+
 
         // set the location of the virology results upload location
         goToEHRFolder();
@@ -1595,6 +1612,10 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         navigateToFolder(PROJECT_NAME, PRIVATE_FOLDER);
         waitForText(tableName);
         clickAndWait(Locator.bodyLinkContainingText(tableName));
+    }
+    public LocalDate convertToLocalDateViaSqlDate(Date dateToConvert)
+    {
+        return new java.sql.Date(dateToConvert.getTime()).toLocalDate();
     }
 
     //@Test - old ext form
@@ -2735,8 +2756,22 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         SelectRowsCommand sr = new SelectRowsCommand("study","Virology Results");
         sr.addFilter("taskid", VIROLOGY_CLINPATH_TASKID, Filter.Operator.EQUAL);
         SelectRowsResponse resp2 = sr.execute(createDefaultConnection(), EHR_FOLDER_PATH);
+        //check that the results got uploaded
         Assert.assertTrue(resp2.getRowCount().intValue() > 0);
+        //check that the data from in the excel file matches the results, this tests GetVirologyResultsFromFileAction action,
+        // as well as the logic the Import Results From File button in ehrGridFormPanel.js
+        Map<String, Object> resultRow = resp2.getRows().get(0);
+        Assert.assertEquals(VIROLOGY_RESULT_DATA.get("Id"), resultRow.get("Id"));
+        Assert.assertEquals(VIROLOGY_RESULT_DATA.get("Date"), convertToLocalDateViaSqlDate((Date) resultRow.get("date")).toString());
+        Assert.assertEquals(VIROLOGY_RESULT_DATA.get("Sample Type"), resultRow.get("source"));
+        Assert.assertEquals(VIROLOGY_RESULT_DATA.get("Virus"), resultRow.get("virus"));
+        Assert.assertEquals(VIROLOGY_RESULT_DATA.get("Method"), resultRow.get("method"));
+        Assert.assertEquals(VIROLOGY_RESULT_DATA.get("Result"), resultRow.get("result"));
+        Assert.assertEquals(VIROLOGY_RESULT_DATA.get("Qualifier"), resultRow.get("qualresult"));
+        Assert.assertEquals(VIROLOGY_RESULT_DATA.get("Remark"), resultRow.get("performing_lab"));
     }
+
+
 
     @Test
     public void testClinpathVirologyBulkUploadValidations()


### PR DESCRIPTION
#### Rationale
The addRecord() method in ehrGridFormPanel.js was modifying the date field for the virologyResults and incorrectly set the virology results' date to today's date instead of the date from the excel file. This PR fixes this problem and adds test coverage for it. It's likely that this bug has been around for a while and has gone unnoticed. A couple examples here catch my eye: [[1](https://ehr.primate.wisc.edu/ehr/WNPRC/EHR/manageTask.view?formtype=Clinpath&taskid=4E86419A-CB95-1039-8C91-DE12D6BFE970)] and [[2](https://ehr.primate.wisc.edu/ehr/WNPRC/EHR/manageTask.view?formtype=Clinpath&taskid=66FAB83A-0A35-1038-AA18-4AC5577E1A90)]. The date should match the collection date for the clinpath run, and it is actually matching the date the task was due/modified. From what I can tell this has only affected 9 tasks (about 900 virology records, out of a total of about 143K records).

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Fix for frontend bug
* Add test coverage
* Adjust study dataset metadata to match the current state of the virologyResults table
