### PR TITLE
Update virology test to use 'SimplePostCommand'

### DIFF
--- a/WNPRC_Virology/test/src/org/labkey/test/tests/wnprc_virology/WNPRC_VirologyTest.java
+++ b/WNPRC_Virology/test/src/org/labkey/test/tests/wnprc_virology/WNPRC_VirologyTest.java
@@ -1,28 +1,17 @@
 package org.labkey.test.tests.wnprc_virology;
 
-import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.InsertRowsCommand;
 import org.labkey.remoteapi.query.SaveRowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
-import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.ModulePropertyValue;
 import org.labkey.test.TestFileUtils;
@@ -36,19 +25,24 @@ import org.labkey.test.tests.di.ETLHelper;
 import org.labkey.test.tests.external.labModules.ViralLoadAssayTest;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PortalHelper;
-import org.labkey.test.util.PostgresOnlyTest;
 import org.labkey.test.util.RemoteConnectionHelper;
 import org.labkey.test.util.SchemaHelper;
 import org.labkey.test.util.ext4cmp.Ext4CmpRef;
 import org.labkey.test.util.ext4cmp.Ext4ComboRef;
 import org.labkey.test.util.ext4cmp.Ext4FieldRef;
-import org.labkey.test.util.Ext4Helper;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static org.labkey.test.WebTestHelper.buildRelativeUrl;
 
@@ -212,7 +206,7 @@ public class WNPRC_VirologyTest extends ViralLoadAssayTest
         importFolderFromPath(1);
         setupNotificationService();
 
-        PostCommand command = new PostCommand("wnprc_virology", "alterEHRBillingAliasesPKSequence");
+        SimplePostCommand command = new SimplePostCommand("wnprc_virology", "alterEHRBillingAliasesPKSequence");
         command.setTimeout(1200000);
         CommandResponse response = command.execute(connection, PROJECT_NAME_EHR);
         Assert.assertTrue(response.getStatusCode() < 400);
@@ -332,7 +326,7 @@ public class WNPRC_VirologyTest extends ViralLoadAssayTest
         _apiPermissionsHelper.setUserPermissions(TEST_USER, "WNPRC Viral Load Reader");
 
         Connection connection = createDefaultConnection();
-        PostCommand command = new PostCommand("wnprc_virology", "startRSEHRJob");
+        SimplePostCommand command = new SimplePostCommand("wnprc_virology", "startRSEHRJob");
         command.setTimeout(1200000);
         CommandResponse response = command.execute(connection, getProjectNameRSEHR());
         Assert.assertTrue(response.getStatusCode() < 400);
@@ -562,7 +556,7 @@ public class WNPRC_VirologyTest extends ViralLoadAssayTest
 
         //run the job with the new permissions
         Connection connection = createDefaultConnection();
-        PostCommand command = new PostCommand("wnprc_virology", "startRSEHRJob");
+        SimplePostCommand command = new SimplePostCommand("wnprc_virology", "startRSEHRJob");
         command.setTimeout(1200000);
         CommandResponse response = command.execute(connection, getProjectNameRSEHR());
         Assert.assertTrue(response.getStatusCode() < 400);


### PR DESCRIPTION
#### Rationale
Test compilation broke after merging forward changes from 22.11.
This `PostCommand` constructor was removed from the remote API in [v5.0.0](https://github.com/LabKey/labkey-api-java/releases/tag/v5.0.0).

#### Related Pull Requests
* https://github.com/LabKey/wnprc-modules/pull/326

#### Changes
* Fix test compilation
