### PR TITLE
WNPRC_Virology use rimraf instead of rm -rf

### DIFF
--- a/WNPRC_Virology/package.json
+++ b/WNPRC_Virology/package.json
@@ -12,7 +12,7 @@
     "build": "npm run build-dev",
     "build-dev": "npm run clean && cross-env NODE_ENV=development webpack --config node_modules/@labkey/build/webpack/dev.config.js --color",
     "build-prod": "npm run clean && cross-env NODE_ENV=production webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile",
-    "clean": "rm -rf resources/web/gen && rm -rf resources/views/gen"
+    "clean": "rimraf resources/web/gen && rimraf resources/views/gen"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
#### Rationale
Using rimraf instead of rm -rf for the NPM clean target allows building on OS's without a shell.

Chad rimraf is what we normally use, let me know if there's any issue using it for this use case.

#### Changes
* Update NPM clean target
