### PR TITLE
Synchronize Google API versions

### DIFF
--- a/GoogleDrive/build.gradle
+++ b/GoogleDrive/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.google.apis:google-api-services-drive:v3-rev85-1.23.0",
+            "com.google.apis:google-api-services-drive:${googleApiServiceDriveVersion}",
             "Google Drive API Client Library for Java",
             "Google",
             "https://developers.google.com/api-client-library/java/apis/drive/v3",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
 moduleContainer=:server:modules:wnprc-modules
 
+googleApiServicesCalendarVersion=v3-rev20230406-2.0.0
+googleApiServiceDriveVersion=v3-rev20230517-2.0.0
+
 jooqVersion=3.8.4


### PR DESCRIPTION
#### Rationale
There's an incompatibility between the versions of googleApiClientVersion and the Google Drive and Google Calendar libraries.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/490

#### Changes
* Manage versions for Drive and Calendar APIs from within wnprc-modules