### PR TITLE
Moving Location out from a query and into the qview.xml

### DIFF
--- a/WNPRC_EHR/resources/queries/study/waterTotalByDate.sql
+++ b/WNPRC_EHR/resources/queries/study/waterTotalByDate.sql
@@ -17,9 +17,7 @@ SELECT
        waterSummary.performedConcat,
        odrwc.currentWaterCondition,
        waterSummary.project,
-       waterSummary.qcstate,
-       waterSummary.curRoom,
-       waterSummary.curCage
+       waterSummary.qcstate
 
 FROM ehr_lookups.calendar cal
  LEFT OUTER JOIN (SELECT drwc.Id AS Id,
@@ -45,8 +43,6 @@ LEFT OUTER JOIN(
     COALESCE(GROUP_CONCAT(iwg.performedby, ';'),'') AS performedConcat,
     MAX(iwg.project) AS project,
     COALESCE(MAX(iwg.qcstate),1) AS qcstate,
-    MAX(iwg.id.curLocation.room) as curRoom,
-    MAX(iwg.id.curLocation.cage) as curCage,
     FROM study.waterGiven iwg WHERE qcstate.label = 'Completed'
     GROUP BY iwg.Id, CAST(iwg.date AS DATE)
     )waterSummary

--- a/WNPRC_EHR/resources/queries/study/waterTotalByDate/.qview.xml
+++ b/WNPRC_EHR/resources/queries/study/waterTotalByDate/.qview.xml
@@ -1,6 +1,7 @@
 <customView xmlns="http://labkey.org/data/xml/queryCustomView">
     <columns>
         <column name="Id" />
+        <column name="Id/curLocation/location"/>
         <column name="date" />
         <column name="TotalWater" />
         <column name="provideFruit"/>

--- a/WNPRC_EHR/resources/queries/study/waterTotalByDateWithWeight.sql
+++ b/WNPRC_EHR/resources/queries/study/waterTotalByDateWithWeight.sql
@@ -19,7 +19,6 @@ SELECT wtbd.Id as Id,
        waterScheduledAnimalsOuter.project,
        wtbd.performedConcat,
        wtbd.qcstate,
-       wtbd.curRoom || '-' || wtbd.curCage AS location,
        'waterTotal' AS dataSource
 FROM study.waterTotalByDate wtbd
 

--- a/WNPRC_EHR/resources/queries/study/waterTotalByDateWithWeight/.qview.xml
+++ b/WNPRC_EHR/resources/queries/study/waterTotalByDateWithWeight/.qview.xml
@@ -1,6 +1,7 @@
 <customView xmlns="http://labkey.org/data/xml/queryCustomView">
     <columns>
         <column name="Id"/>
+        <column name="Id/curLocation/location"/>
         <column name="date"/>
         <column name="TotalWater"/>
         <column name="mlsPerKg"/>

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/husbandry/WaterCalendar.jsp
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/husbandry/WaterCalendar.jsp
@@ -814,7 +814,7 @@
                     $('#waterInformation').collapse('hide');
                     $('#waterTotalInformation').collapse('show');
                     WebUtils.VM.taskDetails["volume"](info.event.extendedProps.rawRowData.TotalWater.toString());
-                    WebUtils.VM.taskDetails["location"](info.event.extendedProps.rawRowData.location.toString());
+                    WebUtils.VM.taskDetails["location"](info.event.extendedProps.rawRowData["Id/curLocation/location"].toString());
                 }else{
                     $('#waterInformation').collapse('show');
                     $('#waterTotalInformation').collapse('hide');


### PR DESCRIPTION
#### Rationale
User want to have animal location for animals that do not have records in the water given table. This change removes the location from the water given queried table and adds it to the .qview.xml where the data is needed.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
