### PR TITLE
Move Google API client version property out of server

### DIFF
--- a/WNPRC_Virology/src/org/labkey/wnprc_virology/WNPRC_VirologyController.java
+++ b/WNPRC_Virology/src/org/labkey/wnprc_virology/WNPRC_VirologyController.java
@@ -339,7 +339,7 @@ public class WNPRC_VirologyController extends SpringActionController
                 SQLFragment sql;
                 if (scope.getSqlDialect().isPostgreSQL())
                 {
-                    sql = new SQLFragment("ALTER SEQUENCE ehr_billing.aliases_rowid_seq RESTART WITH 96;\n");
+                    sql = new SQLFragment("ALTER SEQUENCE ehr_billing.aliases_rowid_seq RESTART WITH 96");
                     new SqlExecutor(scope).execute(sql);
                 }
                 tx.commit();

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,6 @@ moduleContainer=:server:modules:wnprc-modules
 
 googleApiServicesCalendarVersion=v3-rev20230406-2.0.0
 googleApiServiceDriveVersion=v3-rev20230517-2.0.0
+googleApiClientVersion=2.2.0
 
 jooqVersion=3.8.4


### PR DESCRIPTION
#### Rationale
Google API client is used by WNPRC modules only, so maintain its version property here

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47993

#### Related Pull Requests
* https://github.com/LabKey/server/pull/503
