### PR TITLE
Filter out viral load samples that were never submitted

### DIFF
--- a/WNPRC_Virology/resources/queries/lists/rsehr_viral_loads.sql
+++ b/WNPRC_Virology/resources/queries/lists/rsehr_viral_loads.sql
@@ -36,7 +36,7 @@ LEFT JOIN Site.{substitutePath moduleProperty('WNPRC_Virology', 'virologyEHRVLSa
     ON vsq.Id = v.subjectId AND vsq.Sample_date = v.date
 
 WHERE
-    (q.QC_Pass = true OR v.viralLoadScientific = 0.0) AND v.subjectId NOT LIKE '%STD_%' AND v.subjectId NOT LIKE '%CTL%' AND v.subjectId NOT LIKE '%PosControl%' AND v.subjectId NOT LIKE '%NegControl%' AND v.subjectId NOT LIKE '%negative%'
+    (q.QC_Pass = true OR v.viralLoadScientific = 0.0) AND vsq.status.Status != '10-never submitted' AND v.subjectId NOT LIKE '%STD_%' AND v.subjectId NOT LIKE '%CTL%' AND v.subjectId NOT LIKE '%PosControl%' AND v.subjectId NOT LIKE '%NegControl%' AND v.subjectId NOT LIKE '%negative%'
 
 -- groupBy viral load so these can be averaged
 GROUP BY


### PR DESCRIPTION
#### Rationale
Adjust the query that ETLs over to RSEHR server to filter out an additional qc status.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* See sql file
