### PR TITLE
Issue 43420: Swap jTidy --> jSoup

### DIFF
--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "org.jsoup:jsoup:1.15.4",
+            "org.jsoup:jsoup:${jsoupVersion}",
             "jsoup: Java HTML Parser",
             "jsoup",
             "https://github.com/jhy/jsoup",


### PR DESCRIPTION
#### Rationale
Use the centrally managed jSoup version

### Related Pull Requests
* https://github.com/LabKey/server/pull/514

#### Changes
* Use property instead of hard-coded version