### PR TITLE
Add in distinct for replicate fields

### DIFF
--- a/WNPRC_Virology/resources/queries/lists/rsehr_viral_loads.sql
+++ b/WNPRC_Virology/resources/queries/lists/rsehr_viral_loads.sql
@@ -23,7 +23,7 @@ SELECT
     v.comment AS comment,
     v.run.exptNumber as experiment_number,
     vsq.funding_string as account,
-    GROUP_CONCAT( CAST(v.viralLoadScientific AS BIGINT ), ' ; ') AS viral_load_replicates,
+    GROUP_CONCAT( DISTINCT CAST(v.viralLoadScientific AS BIGINT ), ' ; ') AS viral_load_replicates,
     --COUNT(v.viralLoadScientific) AS replicate_count,
 FROM Site.{substitutePath moduleProperty('WNPRC_Virology', 'EHRViralLoadAssayDataPath')}.assay.Viral_Loads.Viral_Load.Data v
 


### PR DESCRIPTION
#### Rationale
Do not show repeat replicates. The various fields in the group-by section throw it off, and get tricky to tease out when we are joining with the sample tracker based on animal id and date.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
