### PR TITLE
Bump transitive dependencies of HTSJDK and Picard versions

### DIFF
--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.google.auth:google-auth-library-oauth2-http:1.10.0",
+            "com.google.auth:google-auth-library-oauth2-http:1.19.0",
             "Google Auth Library",
             "Google",
             "https://github.com/googleapis/google-auth-library-java",


### PR DESCRIPTION
#### Rationale
There are newer versions of a handful of Google libraries. We need to synchronize our preferred version across modules

#### Related Pull Requests
* https://github.com/LabKey/server/pull/541

#### Changes
* Update to new version of google-auth-library-oauth2-http
