### PR TITLE
Rounding viral load replicates

### DIFF
--- a/WNPRC_Virology/resources/queries/lists/rsehr_viral_loads.sql
+++ b/WNPRC_Virology/resources/queries/lists/rsehr_viral_loads.sql
@@ -23,7 +23,8 @@ SELECT
     v.comment AS comment,
     v.run.exptNumber as experiment_number,
     vsq.funding_string as account,
-    GROUP_CONCAT( DISTINCT CAST(v.viralLoadScientific AS BIGINT ), ' ; ') AS viral_load_replicates,
+    --requires an explicit CAST into NUMERIC, as LabKey SQL does not check data types for function arguments
+    GROUP_CONCAT(DISTINCT CAST(ROUND(v.viralLoadScientific, 3) as NUMERIC), ' ; ') as viral_load_replicates
     --COUNT(v.viralLoadScientific) AS replicate_count,
 FROM Site.{substitutePath moduleProperty('WNPRC_Virology', 'EHRViralLoadAssayDataPath')}.assay.Viral_Loads.Viral_Load.Data v
 

--- a/WNPRC_Virology/resources/queries/lists/rsehr_viral_loads.sql
+++ b/WNPRC_Virology/resources/queries/lists/rsehr_viral_loads.sql
@@ -23,7 +23,7 @@ SELECT
     v.comment AS comment,
     v.run.exptNumber as experiment_number,
     vsq.funding_string as account,
-    GROUP_CONCAT( CAST(v.viralLoadScientific AS BIGINT ), ' ; ') AS viral_load_replicates,
+    GROUP_CONCAT( DISTINCT CAST(v.viralLoadScientific AS BIGINT ), ' ; ') AS viral_load_replicates,
     --COUNT(v.viralLoadScientific) AS replicate_count,
 FROM Site.{substitutePath moduleProperty('WNPRC_Virology', 'EHRViralLoadAssayDataPath')}.assay.Viral_Loads.Viral_Load.Data v
 


### PR DESCRIPTION
#### Rationale
Don't cast replicates to bigint, round them vals to 3 decimal places

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
