### PR TITLE
Update CSS image paths

### DIFF
--- a/AnimalRequests/src/client/theme/css/index.css
+++ b/AnimalRequests/src/client/theme/css/index.css
@@ -136,7 +136,7 @@ select {
     border-radius: 1px;
     -moz-appearance: none;
     -webkit-appearance: none;
-    background: url(../../../../../../platform/internal/webapp/_images/arrow_down.png) right no-repeat !important;
+    background: url("../../../../../../platform/core/webapp/_images/arrow_down.png") right no-repeat !important;
     text-transform: Capitalize !important;
 
 }
@@ -146,7 +146,7 @@ select {
     text-align: center;
     display: block;
     position: relative;
-    background: url(../../../../../../platform/internal/webapp/_images/ajax-loading.gif) left no-repeat !important;
+    background: url("../../../../../../platform/core/webapp/_images/ajax-loading.gif") left no-repeat !important;
     background-size: cover;
     font-size: 2em;
     padding: 20px 0 0 0;

--- a/WNPRC_EHR/src/client/theme/css/index.css
+++ b/WNPRC_EHR/src/client/theme/css/index.css
@@ -90,7 +90,7 @@
 }
 
 .loading {
-  background-image: url("../../../../../../platform/internal/webapp/_images/ajax-loading.gif");
+  background-image: url("../../../../../../platform/core/webapp/_images/ajax-loading.gif");
   background-size: 25px 25px;
   background-repeat: no-repeat;
   opacity: 0;


### PR DESCRIPTION
#### Rationale
The related PR moved non-code resources from internal to core. After that was done, a merge from 22.11 was still referencing those references in internal. This fixes those paths.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4006

#### Changes
* Update file paths to CSS resources now in core
