### PR TITLE
Issue 48499: Use preferred SecurityPolicyManager.savePolicy() variant

### DIFF
--- a/DBUtils/api-src/org/labkey/dbutils/api/service/ContainerHelper.java
+++ b/DBUtils/api-src/org/labkey/dbutils/api/service/ContainerHelper.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.Module;
+import org.labkey.api.security.User;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -40,7 +41,7 @@ public class ContainerHelper {
             String nextPiece = pieces.remove(pieces.size() - 1);
 
             // Get the next container, creating it if it doesn't exist
-            Container nextContainer = ContainerManager.ensureContainer(lastContainer, nextPiece);
+            Container nextContainer = ContainerManager.ensureContainer(lastContainer, nextPiece, User.getAdminServiceUser());
 
             // Push the new container onto our stack
             containerStack.add(nextContainer);
@@ -54,19 +55,19 @@ public class ContainerHelper {
     }
 
     private static Container getDbUtilsContainer() {
-        return ContainerManager.ensureContainer(ContainerManager.getRoot(), DBUTILS_PROJECT);
+        return ContainerManager.ensureContainer(ContainerManager.getRoot(), DBUTILS_PROJECT, User.getAdminServiceUser());
     }
 
     public static Container getPrivateContainer() {
-        return ContainerManager.ensureContainer(getDbUtilsContainer(), PRIVATE_CONTAINER);
+        return ContainerManager.ensureContainer(getDbUtilsContainer(), PRIVATE_CONTAINER, User.getAdminServiceUser());
     }
 
     private static Container getPrivateModulesContainer() {
-        return ContainerManager.ensureContainer(getPrivateContainer(), MODULES_CONTAINER);
+        return ContainerManager.ensureContainer(getPrivateContainer(), MODULES_CONTAINER, User.getAdminServiceUser());
     }
 
     public static Container getPrivateContainerForModule(Module module) {
-        Container container = ContainerManager.ensureContainer(getPrivateModulesContainer(), module.getName().toLowerCase());
+        Container container = ContainerManager.ensureContainer(getPrivateModulesContainer(), module.getName().toLowerCase(), User.getAdminServiceUser());
 
         // Ensure
         Set<Module> activeModules = container.getActiveModules();

--- a/SelfRegistration/src/org/labkey/selfregistration/SelfRegistrationController.java
+++ b/SelfRegistration/src/org/labkey/selfregistration/SelfRegistrationController.java
@@ -42,6 +42,7 @@ import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.security.roles.SubmitterRole;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.TestContext;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.security.xml.GroupEnumType;
@@ -297,7 +298,7 @@ public class SelfRegistrationController extends SpringActionController
         {
             // create container
             Container rootContainer = ContainerManager.getRoot();
-            Container container = ContainerManager.createContainer(rootContainer,"PrivateTest");
+            Container container = ContainerManager.createContainer(rootContainer,"PrivateTest", TestContext.get().getUser());
             Group group = GroupManager.getGroup(rootContainer, "Guests", GroupEnumType.SITE);
             if (null == group)
             {
@@ -308,7 +309,7 @@ public class SelfRegistrationController extends SpringActionController
             RoleManager.getAllRoles();
             //what is the roleName for submitter?
             policy.addRoleAssignment(group, SubmitterRole.class);
-            SecurityPolicyManager.savePolicy(policy);
+            SecurityPolicyManager.savePolicy(policy, TestContext.get().getUser());
 
             // ensure the issue module is enabled for this folder
             Module issueModule = ModuleLoader.getInstance().getModule("Issues");

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/DatasetImportHelperIntegrationTest.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/DatasetImportHelperIntegrationTest.java
@@ -42,7 +42,7 @@ public class DatasetImportHelperIntegrationTest extends Assert
     @Before
     public void createContainer()
     {
-        _container = ContainerManager.ensureContainer(JunitUtil.getTestContainer(), TEST_CONTAINER_NAME);
+        _container = ContainerManager.ensureContainer(JunitUtil.getTestContainer(), TEST_CONTAINER_NAME, TestContext.get().getUser());
         _user = TestContext.get().getUser();
     }
 

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -45,6 +45,7 @@ import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.QuerySchema;
 import org.labkey.api.resource.Resource;
+import org.labkey.api.security.User;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.api.view.template.ClientDependency;
@@ -471,13 +472,13 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
 
     public static Container getDefaultContainer() {
         if (ContainerManager.getForPath("/WNPRC") == null) {
-            ContainerManager.createContainer(ContainerManager.getRoot(), "WNPRC");
+            ContainerManager.createContainer(ContainerManager.getRoot(), "WNPRC", User.getAdminServiceUser());
         }
         Container wnprcContainer = ContainerManager.getForPath("/WNPRC");
 
         Container ehrContainer = wnprcContainer.getChild("EHR");
         if (ehrContainer == null) {
-            ContainerManager.createContainer(wnprcContainer, "EHR");
+            ContainerManager.createContainer(wnprcContainer, "EHR", User.getAdminServiceUser());
             ehrContainer = wnprcContainer.getChild("EHR");
         }
 


### PR DESCRIPTION
#### Rationale
We're uneven in terms of the validation and auditing we do for saving SecurityPolicies and related updates, and want to be more consistent.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4704

#### Changes
* Let modules register ContainerSecurableResourceProviders instead of having Container know about them all
* Remove the `savePolicy` and `createContainer` methods that don't take a user, check permissions, or log for audit purposes
* Introduce `User.getAdminServiceUser()` for `sudo` like scenarios or when we're doing an operation not initiated by a user, like bootstrapping the server
* Update callers