### PR TITLE
Restoring weights navigation feature

### DIFF
--- a/WNPRC_EHR/src/client/theme/css/index.css
+++ b/WNPRC_EHR/src/client/theme/css/index.css
@@ -14,6 +14,8 @@
 }
 
 .react-datepicker-wrapper {
+  margin-bottom: 5px;
+  height: 30px;
   width: 100%;
   max-width: 225px;
 }
@@ -196,6 +198,8 @@ select[id^="restraint"] {
   float:right;
   margin: 4px;
   z-index: 0;
+  top: .85rem;
+  left: 1px;
 }
 
 @keyframes slideout {
@@ -230,10 +234,10 @@ select[id^="restraint"] {
 .react-datepicker__input-container > input {
   width: 100%;
   min-height: 1px;
-  height: 27px;
-  border: 1px solid rgb(166,166,166);
+  height: 26px;
+  border: none;
   border-image: initial;
-  padding-left: 15px;
+  padding-left: 8px;
   padding-right: 15px;
   font-size: 14px;
 }

--- a/WNPRC_EHR/src/client/theme/css/react-datepicker.css
+++ b/WNPRC_EHR/src/client/theme/css/react-datepicker.css
@@ -75,7 +75,7 @@
   background-color: #fff;
   color: #000;
   border: 1px solid #aeaeae;
-  border-radius: 0.3rem;
+  border-radius: 0;
   display: inline-block;
   position: relative;
 }

--- a/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightForm.tsx
+++ b/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightForm.tsx
@@ -36,8 +36,7 @@ const EnterWeightForm: React.FunctionComponent<WeightFormProps> = props => {
     liftUpAnimalInfo,
     liftUpVal,
     liftUpErrorLevel,
-    liftUpValidation,
-    triggerReportFormValidity
+    liftUpValidation
   } = props;
   const [prevweight, setPrevWeight] = useState<number>(null);
   const [animalInfo, setAnimalInfo] = useState<AnimalInfoProps>(null);

--- a/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightForm.tsx
+++ b/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightForm.tsx
@@ -84,7 +84,7 @@ const EnterWeightForm: React.FunctionComponent<WeightFormProps> = props => {
 
 
   const handleKeyDown = (event : React.KeyboardEvent<HTMLInputElement>) => {
-    jumpToNextRecordOnEnter(event);
+    jumpToNextRecordOnEnter(event, index, "_");
   }
   //validate items to set error levels which determine which buttons are disabled
   const validateItems = (name: string, value: string | number | object) => {

--- a/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightForm.tsx
+++ b/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightForm.tsx
@@ -5,8 +5,9 @@ import "../../../theme/css/index.css";
 import "../../../theme/css/tooltip.css";
 import {
   enteredWeightIsGreaterThanPrevWeight,
-  enteredWeightIsLessThanPrevWeight
-} from "../../query/helpers";
+  enteredWeightIsLessThanPrevWeight,
+  jumpToNextRecordOnEnter
+} from '../../query/helpers';
 import { useEffect, useState } from "react";
 import { labkeyActionSelectWithPromise } from "../../query/actions";
 import { useRef, useContext } from "react";
@@ -82,13 +83,8 @@ const EnterWeightForm: React.FunctionComponent<WeightFormProps> = props => {
 
 
 
-  const handleKeyDown = (event:React.KeyboardEvent<HTMLInputElement>) => {
-    // trigger html form validation when the return key is pressed. this restores desired behavior that was otherwise captured by
-    // the html 'required' fields when the form was able to submit, since then, the submit buttons have been disabled
-    // and the form submit does not get triggered unless basic validation is passing
-    if (event.key === 'Enter') {
-      triggerReportFormValidity();
-    }
+  const handleKeyDown = (event : React.KeyboardEvent<HTMLInputElement>) => {
+    jumpToNextRecordOnEnter(event);
   }
   //validate items to set error levels which determine which buttons are disabled
   const validateItems = (name: string, value: string | number | object) => {

--- a/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightForm.tsx
+++ b/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightForm.tsx
@@ -35,7 +35,8 @@ const EnterWeightForm: React.FunctionComponent<WeightFormProps> = props => {
     liftUpAnimalInfo,
     liftUpVal,
     liftUpErrorLevel,
-    liftUpValidation
+    liftUpValidation,
+    triggerReportFormValidity
   } = props;
   const [prevweight, setPrevWeight] = useState<number>(null);
   const [animalInfo, setAnimalInfo] = useState<AnimalInfoProps>(null);
@@ -80,6 +81,15 @@ const EnterWeightForm: React.FunctionComponent<WeightFormProps> = props => {
   },[anyErrors]);
 
 
+
+  const handleKeyDown = (event:React.KeyboardEvent<HTMLInputElement>) => {
+    // trigger html form validation when the return key is pressed. this restores desired behavior that was otherwise captured by
+    // the html 'required' fields when the form was able to submit, since then, the submit buttons have been disabled
+    // and the form submit does not get triggered unless basic validation is passing
+    if (event.key === 'Enter') {
+      triggerReportFormValidity();
+    }
+  }
   //validate items to set error levels which determine which buttons are disabled
   const validateItems = (name: string, value: string | number | object) => {
     if (value == "" && name == "animalid") {
@@ -254,6 +264,9 @@ const EnterWeightForm: React.FunctionComponent<WeightFormProps> = props => {
             onBlur={e => {
               checkWeights(e);
             }}
+            onKeyDown={handleKeyDown}
+            /* disables scrolling on this input, prevents weight from accidentally being changed */
+            onWheel={(e:React.UIEvent<HTMLElement>)=> {(e.target as HTMLInputElement).blur()}}
             required
           />
           {weightWarning && (

--- a/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
+++ b/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
@@ -720,7 +720,7 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
                 .filter(item => item.command.value != "delete")
                 .map((item, i) => (
                   <div className={`row ${item.visibility.value}`} key={i}>
-                    <div className="col-xs-10">
+                    <div className="col-xs-11">
                       <div className="row card" key={i}>
                         <div
                           className={`card-header ${item.validated.value ? "valid" : "invalid"}`}
@@ -805,8 +805,8 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
                       >
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
-                          width="48"
-                          height="48"
+                          width="32"
+                          height="32"
                           viewBox="0 0 24 24"
                         >
                           <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
@@ -844,7 +844,7 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
             </button>
             {errorLevel === "submittable" &&
             <div>
-              <span id="invalid-tooltip" data-tooltip={"Fill in missing information for boxes outlined in red."}>⚠️</span>
+              <span id="invalid-tooltip" data-tooltip={"Fill in missing information for boxes marked with ❗"}>⚠️ </span>
             </div>
             }
           </div>

--- a/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
+++ b/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
@@ -66,6 +66,7 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
   const [errorLevel, setErrorLevel] = useState<FormErrorLevels>("no-action");
   const [singleEditMode, setSingleEditMode] = useState(false);
   const [enableSave, setEnableSave] = useState<boolean>(false);
+  const [allExpanded, setAllExpanded] = useState<boolean>(true);
 
   const formEl = useRef(null);
 
@@ -150,6 +151,7 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
         }
       });
       setFormDataInAppContext(animaldata);
+      setAllExpanded(false);
       setLocLoading(false);
       setErrorLevel("saveable");
     });
@@ -520,6 +522,19 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
     setFormDataInAppContext(copyformdata);
   };
 
+
+  const toggleExpandAllRecords = () => {
+    let copyformdata: Array<RowObj> = [...formdata];
+    copyformdata.forEach((item) => {
+      if (allExpanded) {
+        item["collapsed"]["value"] = true;
+      } else {
+        item["collapsed"]["value"] = false;
+      }
+    })
+    setAllExpanded(!allExpanded);
+    setFormDataInAppContext(copyformdata);
+  }
   const toggleCollapse = (item: RowObj, i) => {
     let copyitem: RowObj = Object.assign({},item);
     copyitem["collapsed"]["value"] = false;
@@ -664,6 +679,14 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
           onClick={handleShowModal}
         >
           Add Batch
+        </Button>
+        <Button
+            variant="primary"
+            className="wnprc-secondary-btn"
+            id="expand-all"
+            onClick={ () => {toggleExpandAllRecords()}}
+        >
+          {allExpanded ? "Collapse All" : "Expand All"}
         </Button>
         <Button
           variant="primary"

--- a/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
+++ b/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
@@ -214,6 +214,7 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
     }
     //set the ask id
     setEditMode(true);
+    setAllExpanded(false);
 
     //if there's no task id, then we don't have to update the task table... just update the records
     //or more generally if we are in edit mode, we don't have ot update the task id...
@@ -421,9 +422,9 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
       changeActionToUpdate();
       window.scrollTo(0,0);
       setEndTimeInAppContext(new Date());
-    }).catch(()=>{
+    }).catch((e)=>{
       setWasError(true);
-      setErrorText("Error during operation.");
+      setErrorText("Error during operation. " + e.exception);
       window.scrollTo(0,0);
     });
 

--- a/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
+++ b/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
@@ -625,10 +625,6 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
     setShowModal("none");
   };
 
-  const triggerReportFormValidity = () => {
-    formEl.current.reportValidity();
-  }
-
   const triggerUpAnyErrors = e => {
     setErrorLevel(e);
   };
@@ -809,7 +805,6 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
                               infoState={liftUpInfoState}
                               liftUpErrorLevel={triggerUpAnyErrors}
                               liftUpValidation={liftUpValidationState}
-                              triggerReportFormValidity={triggerReportFormValidity}
                             />
                           </div>
                         </div>

--- a/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
+++ b/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
@@ -110,6 +110,13 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
     setBatchAddUsedInAppContext();
   };
 
+  const deleteAll = () => {
+    setFormDataInAppContext([]);
+    setAnimalInfo(null);
+    setInfoState("waiting");
+    flipModalState();
+  }
+
   useEffect(() => {
     if (location.length == 0) {
       return;
@@ -691,13 +698,9 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
         <Button
           variant="primary"
           className="wnprc-secondary-btn"
-          id="delete-record"
+          id="delete-all"
           disabled={singleEditMode}
-          onClick={() => {
-            setFormDataInAppContext([]);
-            setAnimalInfo(null);
-            setInfoState("waiting");
-          }}
+          onClick={handleShowModal}
         >
           Delete All
         </Button>
@@ -733,6 +736,16 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
             flipState={flipModalState}
           />
         )}
+        {showModal == "delete-all" && (
+        <SubmitModal
+            name={"delete-all"}
+            title="Delete All"
+            submitAction={deleteAll}
+            bodyText={"Delete All Records?"}
+            submitText="Yes"
+            flipState={flipModalState}
+            enabled={true}
+        />)}
         <form className="weights-form" ref={formEl}>
 
           {locloading ? (

--- a/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
+++ b/WNPRC_EHR/src/client/weight/containers/Forms/EnterWeightFormContainer.tsx
@@ -602,6 +602,10 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
     setShowModal("none");
   };
 
+  const triggerReportFormValidity = () => {
+    formEl.current.reportValidity();
+  }
+
   const triggerUpAnyErrors = e => {
     setErrorLevel(e);
   };
@@ -768,12 +772,13 @@ const EnterWeightFormContainer: React.FunctionComponent<any> = props => {
                               infoState={liftUpInfoState}
                               liftUpErrorLevel={triggerUpAnyErrors}
                               liftUpValidation={liftUpValidationState}
+                              triggerReportFormValidity={triggerReportFormValidity}
                             />
                           </div>
                         </div>
                       </div>
                     </div>
-                    <div className="col-xs-2">
+                    <div className="col-xs-1">
                       <button
                         className="remove-record-button"
                         id={`remove-record-btn_${i}`}

--- a/WNPRC_EHR/src/client/weight/query/helpers.ts
+++ b/WNPRC_EHR/src/client/weight/query/helpers.ts
@@ -172,18 +172,17 @@ export const generateUUID = () => {
 };
 
 // Restores a desired behavior on the card-based react forms:
-// Given a keyboard event (w/ assoc element target), and naming scheme of the input id as "id_{idx}"
-// where idx is the index of the record in the form, jump to the next record, same field, when 'Enter' is pressed.
-export const jumpToNextRecordOnEnter = (event : React.KeyboardEvent<HTMLInputElement>) => {
+// Given a keyboard event (w/ assoc element target), and naming scheme of the input id as event.target.id + id_separator + record_index
+// where record_index is the index of the record in the form, jump to the next record, same field, when 'Enter' is pressed.
+export const jumpToNextRecordOnEnter = (event : React.KeyboardEvent<HTMLInputElement>, record_index: number, id_seperator : string = "") => {
   if (event.key === 'Enter'){
     let the_event = event.target as HTMLInputElement
-    let id_sep : string = "_";
     let curr_field_id : string = the_event.id;
 
     let next_field_el = document.getElementById(
-        curr_field_id.substring(0,curr_field_id.indexOf(id_sep))
-        + id_sep +
-        (parseInt(curr_field_id.substring(curr_field_id.indexOf(id_sep)+1)) + 1).toString()
+        curr_field_id.substring(0,curr_field_id.indexOf(id_seperator))
+        + id_seperator +
+        (record_index + 1).toString()
     )
 
     if (next_field_el) {

--- a/WNPRC_EHR/src/client/weight/query/helpers.ts
+++ b/WNPRC_EHR/src/client/weight/query/helpers.ts
@@ -170,3 +170,24 @@ export const getQCStateByRowId = (id: number) => {};
 export const generateUUID = () => {
   return Utils.generateUUID();
 };
+
+// Restores a desired behavior on the card-based react forms:
+// Given a keyboard event (w/ assoc element target), and naming scheme of the input id as "id_{idx}"
+// where idx is the index of the record in the form, jump to the next record, same field, when 'Enter' is pressed.
+export const jumpToNextRecordOnEnter = (event : React.KeyboardEvent<HTMLInputElement>) => {
+  if (event.key === 'Enter'){
+    let the_event = event.target as HTMLInputElement
+    let id_sep : string = "_";
+    let curr_field_id : string = the_event.id;
+
+    let next_field_el = document.getElementById(
+        curr_field_id.substring(0,curr_field_id.indexOf(id_sep))
+        + id_sep +
+        (parseInt(curr_field_id.substring(curr_field_id.indexOf(id_sep)+1)) + 1).toString()
+    )
+
+    if (next_field_el) {
+      next_field_el.focus();
+    }
+  }
+}

--- a/WNPRC_EHR/src/client/weight/typings/main.ts
+++ b/WNPRC_EHR/src/client/weight/typings/main.ts
@@ -128,7 +128,6 @@ export interface WeightFormProps {
     liftUpAnimalInfo: (animalInfo: AnimalInfoProps) => void;
     liftUpErrorLevel: (errorLevel: string) => void;
     liftUpValidation: (name: string, value: any, index: number) => void;
-    triggerReportFormValidity: () => void;
 }
 
 export interface ModifyRowsCommands {

--- a/WNPRC_EHR/src/client/weight/typings/main.ts
+++ b/WNPRC_EHR/src/client/weight/typings/main.ts
@@ -128,6 +128,7 @@ export interface WeightFormProps {
     liftUpAnimalInfo: (animalInfo: AnimalInfoProps) => void;
     liftUpErrorLevel: (errorLevel: string) => void;
     liftUpValidation: (name: string, value: any, index: number) => void;
+    triggerReportFormValidity: () => void;
 }
 
 export interface ModifyRowsCommands {

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -2438,6 +2438,9 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         Map<String, Object> wt = (Map<String, Object>) r.getRows().get(0).get("weight");
         Assert.assertEquals(null, WEIGHT_VAL, wt.get("value"));
 
+        //make sure we are done saving things
+        waitForText("My Tasks");
+        //navigate to the weights table to click on the task id
         navigateToWeightsTable();
         Map<String, Object> taskidob = (Map<String, Object>) r.getRows().get(0).get("taskid");
         String taskid = taskidob.get("value").toString();

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -2512,13 +2512,34 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
     }
 
     @Test
-    public void testAddBatchIds()
+    public void testAddBatchIds() throws IOException, CommandException
     {
         navigateToWeights();
         addBatchByIds();
-        for (int i = 0; i < ANIMAL_SUBSET_EHR_TEST.length; i++){
+        for (int i = 0; i < ANIMAL_SUBSET_EHR_TEST.length; i++)
+        {
             assertTextPresent(ANIMAL_SUBSET_EHR_TEST[i]);
         }
+        // test the navigating to next weight by hitting enter
+        for (Integer i = 0; i < ANIMAL_SUBSET_EHR_TEST.length; i++)
+        {
+            WebElement el2 = fillAnInput("weight_" + i, "0.489");
+            if (i < ANIMAL_SUBSET_EHR_TEST.length-1)
+            {
+                el2.sendKeys(Keys.ENTER);
+            }
+        }
+
+        waitUntilElementIsClickable("submit-all-btn");
+        clickNewButton("submit-all-btn");
+        clickNewButton("submit-final");
+        waitForText("Success");
+
+        SelectRowsResponse r = fetchWeightData();
+        Map<String, Object> wt = (Map<String, Object>) r.getRows().get(0).get("weight");
+        TestLogger.log(wt.get("value").toString());
+        Assert.assertEquals(null, 0.489, wt.get("value"));
+
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
When the state management for the form submit buttons were improved, users were no longer able to trigger a form submit by hitting 'return' after entering a weight, jumping them to the next empty weight field and speeding up data entry. This behavior was restored with a custom event listener on the weight input.

#### Related Pull Requests
* https://github.com/LabKey/wnprc-modules/pull/375

#### Changes
* Add return event listener to jump to next weight input
* Add collapse/expand button
* Add submit modal to delete button
* Minor css changes
* Added test
* Fix for testEditAndDelete timing issue
