### PR TITLE
22.11 fb grid panel hotfixes

### DIFF
--- a/WNPRC_EHR/resources/queries/study/treatmentSchedule/Master Treatments.qview.xml
+++ b/WNPRC_EHR/resources/queries/study/treatmentSchedule/Master Treatments.qview.xml
@@ -14,6 +14,7 @@
         <column name="enddate"/>
         <column name="TimeOfDay"/>
         <column name="frequency"/>
+        <column name="qcstate"/>
     </columns>
     <sorts>
         <sort column="date" descending="true"/>

--- a/WNPRC_EHR/resources/queries/study/treatmentSchedule/Master Treatments.qview.xml
+++ b/WNPRC_EHR/resources/queries/study/treatmentSchedule/Master Treatments.qview.xml
@@ -11,6 +11,7 @@
         <column name="volume2"/>
         <column name="conc2"/>
         <column name="startdate"/>
+        <column name="enddate"/>
         <column name="TimeOfDay"/>
         <column name="frequency"/>
     </columns>

--- a/WNPRC_EHR/resources/web/wnprc_ehr/reports/PregnancyReport.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/reports/PregnancyReport.js
@@ -4,7 +4,7 @@ EHR.reports.PregnancyReport = function (panel, tab) {
     let config = {
         schemaName: 'study',
         queryName: 'PregnancyInfo',
-        viewName: '',
+        viewName: 'pregnancies_all',
         filterConfig: JSON.stringify({
             subjects: tab.filters.subjects,
             filters: tab.filters,


### PR DESCRIPTION
#### Rationale
Hot-fixes for the views of pregnancies and master treatments reports

#### Related Pull Requests

#### Changes
Changed default view for pregnancies report
Added status and end date columns for master treatments report