### PR TITLE
Issue 48769 - Populate necropsies projects in weights section in Necropsy form

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/dataentry/forms/Necropsy/FormSections/WeightSection.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/dataentry/forms/Necropsy/FormSections/WeightSection.java
@@ -19,12 +19,13 @@ public class WeightSection extends SlaveFormSection {
         Set<String> fields = new HashSet<>();
 
         fields.add("Id");
+        fields.add("project");
 
         return fields;
     }
 
     @Override
     protected List<String> getFieldNames() {
-        return Arrays.asList("Id", "date", "weight", "remark");
+        return Arrays.asList("Id", "project", "date", "weight", "remark");
     }
 }


### PR DESCRIPTION
#### Rationale
Weights dataset has it's own project column. In Necropsy form, the project from the top necropsies section is not populating to project in weights section. This PR fixes the issue.

https://www.labkey.org/WNPRC/support%20tickets/issues-details.view?issueId=48769
