### PR TITLE
Workaround for colony alerts filtering problem

### DIFF
--- a/docker/ehrcron/scripts/automaticAlerts/colonyAlerts.pl
+++ b/docker/ehrcron/scripts/automaticAlerts/colonyAlerts.pl
@@ -275,7 +275,7 @@ $results = LabKey::Query::selectRows(
     -queryName => 'Demographics',
     -sort => 'Id',
     -filterArray => [
-    	['Id/Dataset/Demographics/calculated_status', 'eq', 'Alive'],
+    	['calculated_status', 'eq', 'Alive'],
     	['Id/curLocation/room/room', 'isblank', ''],
     ],
     -requiredVersion => 8.3,
@@ -290,7 +290,7 @@ if(@{$results->{rows}}){
         $email_html .= $row->{'Id'}."<br>";
     };
     	
-	$email_html .= "<p><a href='".$baseUrl."query/".$studyContainer."executeQuery.view?schemaName=study&query.queryName=Demographics&query.Id/curLocation/room~isblank&query.Id/Dataset/Demographics/calculated_status~eq=Alive"."'>Click here to view them</a><br>\n";
+	$email_html .= "<p><a href='".$baseUrl."query/".$studyContainer."executeQuery.view?schemaName=study&query.queryName=Demographics&query.Id/curLocation/room~isblank&query.calculated_status~eq=Alive"."'>Click here to view them</a><br>\n";
 	$email_html .= "<hr>\n";			
 }
 

--- a/docker/ehrcron/scripts/automaticAlerts/colonyAlertsLite.pl
+++ b/docker/ehrcron/scripts/automaticAlerts/colonyAlertsLite.pl
@@ -196,7 +196,7 @@ $results = LabKey::Query::selectRows(
     -schemaName => 'study',
     -queryName => 'Demographics',
     -filterArray => [
-    	['Id/Dataset/Demographics/calculated_status', 'eq', 'Alive'],
+    	['calculated_status', 'eq', 'Alive'],
     	['Id/curLocation/room/room', 'isblank', ''],
     ],
     -requiredVersion => 8.3,
@@ -211,7 +211,7 @@ if(@{$results->{rows}}){
     };
     	
 	$email_html .= "<b>WARNING: There are ".@{$results->{rows}}." living animals that lack an active housing record.</b><br>";
-	$email_html .= "<p><a href='".$baseUrl."query/".$studyContainer."executeQuery.view?schemaName=study&query.queryName=Demographics&query.Id/curLocation/room/room~isblank&query.Id/Dataset/Demographics/calculated_status~eq=Alive"."'>Click here to view them</a><br>\n";#
+	$email_html .= "<p><a href='".$baseUrl."query/".$studyContainer."executeQuery.view?schemaName=study&query.queryName=Demographics&query.Id/curLocation/room/room~isblank&query.calculated_status~eq=Alive"."'>Click here to view them</a><br>\n";#
 	$email_html .= "<hr>\n";			
 }
 


### PR DESCRIPTION
#### Rationale
When the LabKey selectRows filter "Id/Dataset/Demographics/calculated_status" is combined with "Id/curLocation/room/room" filter, causes a postgres error (after the upgrade from postgres 11 to 15): "mergejoin input data is out of order". This is a workaround for that problem.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
