### PR TITLE
Treatments Location Fix and Printing Button Added

### DIFF
--- a/WNPRC_EHR/resources/web/wnprc_ehr/reports/AfternoonTreatmentsReport.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/reports/AfternoonTreatmentsReport.js
@@ -49,7 +49,6 @@ EHR.reports.AfternoonTreatmentsReport = function (panel, tab) {
                 }
             }]),
             filterConfig: JSON.stringify({
-                subjects: tab.filters.subjects,
                 date: panel.getFilterArray(tab).removable[0].value,
                 filters: tab.filters,
             }),

--- a/WNPRC_EHR/resources/web/wnprc_ehr/reports/EveningTreatmentsReport.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/reports/EveningTreatmentsReport.js
@@ -21,7 +21,6 @@ EHR.reports.EveningTreatmentsReport = function (panel, tab) {
                 }
             }]),
             filterConfig: JSON.stringify({
-                subjects: tab.filters.subjects,
                 date: panel.getFilterArray(tab).removable[0].value,
                 filters: tab.filters,
             }),

--- a/WNPRC_EHR/resources/web/wnprc_ehr/reports/IncompleteTreatmentsReport.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/reports/IncompleteTreatmentsReport.js
@@ -49,7 +49,6 @@ EHR.reports.IncompleteTreatmentsReport = function (panel, tab) {
                 }
             }]),
             filterConfig: JSON.stringify({
-                subjects: tab.filters.subjects,
                 date: panel.getFilterArray(tab).removable[0].value,
                 filters: tab.filters,
             }),

--- a/WNPRC_EHR/resources/web/wnprc_ehr/reports/MasterTreatmentsReport.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/reports/MasterTreatmentsReport.js
@@ -21,7 +21,6 @@ EHR.reports.MasterTreatmentsReport = function (panel, tab) {
                 }
             }]),
             filterConfig: JSON.stringify({
-                subjects: tab.filters.subjects,
                 date: panel.getFilterArray(tab).removable[0].value,
                 filters: tab.filters,
             }),

--- a/WNPRC_EHR/resources/web/wnprc_ehr/reports/MorningTreatmentsReport.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/reports/MorningTreatmentsReport.js
@@ -49,7 +49,6 @@ EHR.reports.MorningTreatmentsReport = function (panel, tab) {
                 }
             }]),
             filterConfig: JSON.stringify({
-                subjects: tab.filters.subjects,
                 date: panel.getFilterArray(tab).removable[0].value,
                 filters: tab.filters,
             }),

--- a/WNPRC_EHR/resources/web/wnprc_ehr/reports/PregnancyReport.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/reports/PregnancyReport.js
@@ -6,7 +6,6 @@ EHR.reports.PregnancyReport = function (panel, tab) {
         queryName: 'PregnancyInfo',
         viewName: 'pregnancies_all',
         filterConfig: JSON.stringify({
-            subjects: tab.filters.subjects,
             filters: tab.filters,
         }),
     };

--- a/WNPRC_EHR/src/client/components/DefaultGridPanel.tsx
+++ b/WNPRC_EHR/src/client/components/DefaultGridPanel.tsx
@@ -16,8 +16,6 @@ import "../theme/css/index.css";
 
 // Any props you might use will go here
 interface myProps {
-    schemaName: string;
-    queryName: string
     input?: {
         controller: string,
         view: string,
@@ -43,9 +41,7 @@ const DefaultGridPanelImpl: FC<Props> = ({
     input,
     cellStyles,
     title,
-    columnStyles,
-    queryName,
-    schemaName
+    columnStyles
     }) => {
 
     //declare any states here
@@ -140,7 +136,11 @@ const DefaultGridPanelImpl: FC<Props> = ({
         const { containersModel } = queryModels;
         const view = containersModel.currentView;
         const newFilterArray = containersModel.filterArray.concat(view.filters);
-        const printParams = Query.buildQueryParams(schemaName, queryName, newFilterArray, "");
+        const printParams = Query.buildQueryParams(
+            containersModel.schemaQuery.schemaName,
+            containersModel.schemaQuery.queryName,
+            newFilterArray,
+            "");
 
         window.open(LABKEY.ActionURL.buildURL('query', 'printRows', LABKEY.ActionURL.getContainer(),{
             ...printParams
@@ -193,6 +193,7 @@ const DefaultGridPanelImpl: FC<Props> = ({
                 : <GridPanel
                     model={queryModels.containersModel}
                     ButtonsComponent={renderGridButtons}
+                    ButtonsComponentRight={renderRightGridButtons}
                     actions={actions}
                     asPanel={true}
                     showSearchInput={false}

--- a/WNPRC_EHR/src/client/components/DefaultGridPanel.tsx
+++ b/WNPRC_EHR/src/client/components/DefaultGridPanel.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FC, useEffect, useState } from 'react';
 
 import { produce } from 'immer';
-
+import {Query} from '@labkey/api'
 import {
     ExtendedMap,
     GridPanel,
@@ -16,6 +16,8 @@ import "../theme/css/index.css";
 
 // Any props you might use will go here
 interface myProps {
+    schemaName: string;
+    queryName: string
     input?: {
         controller: string,
         view: string,
@@ -36,13 +38,15 @@ type Props = myProps & InjectedQueryModels;
 // component directly, only the wrapped version below which we expose
 // to users as ExampleGridPanel.
 const DefaultGridPanelImpl: FC<Props> = ({
-                                             actions,
-                                             queryModels,
-                                             input,
-                                             cellStyles,
-                                             title,
-                                             columnStyles
-                                         }) => {
+    actions,
+    queryModels,
+    input,
+    cellStyles,
+    title,
+    columnStyles,
+    queryName,
+    schemaName
+    }) => {
 
     //declare any states here
     const [queryModel, setQueryModel] = useState<QueryModel>(queryModels.containersModel);
@@ -132,6 +136,15 @@ const DefaultGridPanelImpl: FC<Props> = ({
         })
     };
 
+    const onPrint = () => {
+        const { containersModel } = queryModels;
+        const printParams = Query.buildQueryParams(schemaName, queryName, containersModel.filterArray, "date,room,cage");
+
+        window.open(LABKEY.ActionURL.buildURL('query', 'printRows', LABKEY.ActionURL.getContainer(),{
+            ...printParams
+        }));
+    }
+
     // This is an example of a custom button bar element in your GridPanel that can interact with the QueryModel.
     const renderGridButtons = () => {
         return (
@@ -147,6 +160,18 @@ const DefaultGridPanelImpl: FC<Props> = ({
         )
     };
 
+    const renderRightGridButtons = () => {
+        return (
+            <div className={'labkey-button-bar'}>
+                <button className={'btn btn-default'} onClick={onPrint}>
+                    <span className={'fa fa-print'}>
+                    </span>
+                </button>
+
+            </div>
+        )
+    };
+
 
     return (
         <div>
@@ -154,6 +179,7 @@ const DefaultGridPanelImpl: FC<Props> = ({
                 ? <GridPanel
                     model={queryModel}
                     ButtonsComponent={renderGridButtons}
+                    ButtonsComponentRight={renderRightGridButtons}
                     actions={actions}
                     asPanel={true}
                     showSearchInput={false}

--- a/WNPRC_EHR/src/client/components/DefaultGridPanel.tsx
+++ b/WNPRC_EHR/src/client/components/DefaultGridPanel.tsx
@@ -6,15 +6,12 @@ import { produce } from 'immer';
 import {
     ExtendedMap,
     GridPanel,
-    GridProps,
     InjectedQueryModels,
     QueryColumn,
     QueryInfo,
-    QueryModel, selectRows,
+    QueryModel,
     withQueryModels
 } from '@labkey/components';
-import { Filter } from '@labkey/api';
-import { labkeyActionSelectWithPromise } from '../query/helpers';
 import "../theme/css/index.css";
 
 // Any props you might use will go here

--- a/WNPRC_EHR/src/client/components/DefaultGridPanel.tsx
+++ b/WNPRC_EHR/src/client/components/DefaultGridPanel.tsx
@@ -138,7 +138,9 @@ const DefaultGridPanelImpl: FC<Props> = ({
 
     const onPrint = () => {
         const { containersModel } = queryModels;
-        const printParams = Query.buildQueryParams(schemaName, queryName, containersModel.filterArray, "date,room,cage");
+        const view = containersModel.currentView;
+        const newFilterArray = containersModel.filterArray.concat(view.filters);
+        const printParams = Query.buildQueryParams(schemaName, queryName, newFilterArray, "");
 
         window.open(LABKEY.ActionURL.buildURL('query', 'printRows', LABKEY.ActionURL.getContainer(),{
             ...printParams

--- a/WNPRC_EHR/src/client/components/GridPanelConfig.tsx
+++ b/WNPRC_EHR/src/client/components/GridPanelConfig.tsx
@@ -34,7 +34,6 @@ export const GridPanelConfig: FC<configProps> = ({
     const baseFilters = [];
     const filterArray = [];
     if(filterConfig) {
-        const subjects = filterConfig.subjects;
         const filterDate = filterConfig.date;
         const filterType = filterConfig.filters.inputType;
 
@@ -50,6 +49,7 @@ export const GridPanelConfig: FC<configProps> = ({
             } else if (filterType === "multiSubject") {
                 baseFilters.push(Filter.create("Id", filterConfig.filters.nonRemovable['0'].value, Filter.Types.EQUAL.getMultiValueFilter()));
             } else if (filterType === "singleSubject") {
+                const subjects = filterConfig.filters.subjects;
                 baseFilters.push(Filter.create("Id", subjects[0], Filter.Types.EQUAL));
             }
         }

--- a/WNPRC_EHR/src/client/components/GridPanelConfig.tsx
+++ b/WNPRC_EHR/src/client/components/GridPanelConfig.tsx
@@ -31,26 +31,24 @@ export const GridPanelConfig: FC<configProps> = ({
     title,
     columnStyles,
     }) => {
-    const baseFilters = [];
     const filterArray = [];
     if(filterConfig) {
         const subjects = filterConfig.subjects;
         const filterDate = filterConfig.date;
         const filterType = filterConfig.filters.inputType;
 
-
         if (filterType !== "none") {
             if (filterType === "roomCage" && filterConfig.filters.room !== null) {
                 //const area = filterConfig.filters.area.split(',');
                 const room = filterConfig.filters.room.split(',');
                 const cage = filterConfig.filters.cage.split(',');
-                //if (area[0] !== "") baseFilters.push(Filter.create("Id/curLocation/area", area, Filter.Types.EQUAL.getMultiValueFilter()));
-                if (room[0] !== "") baseFilters.push(Filter.create("Id/curLocation/room", room, Filter.Types.EQUAL.getMultiValueFilter()));
-                if (cage[0] !== "") baseFilters.push(Filter.create("Id/curLocation/cage", cage, Filter.Types.EQUAL.getMultiValueFilter()));
+                //if (area[0] !== "") filterArray.push(Filter.create("Id/curLocation/area", area, Filter.Types.EQUAL.getMultiValueFilter()));
+                if (room[0] !== "") filterArray.push(Filter.create("Id/curLocation/room", room, Filter.Types.EQUAL.getMultiValueFilter()));
+                if (cage[0] !== "") filterArray.push(Filter.create("Id/curLocation/cage", cage, Filter.Types.EQUAL.getMultiValueFilter()));
             } else if (filterType === "multiSubject") {
-                baseFilters.push(Filter.create("Id", filterConfig.filters.nonRemovable['0'].value, Filter.Types.EQUAL.getMultiValueFilter()));
+                filterArray.push(Filter.create("Id", filterConfig.filters.nonRemovable['0'].value, Filter.Types.EQUAL.getMultiValueFilter()));
             } else if (filterType === "singleSubject") {
-                baseFilters.push(Filter.create("Id", subjects[0], Filter.Types.EQUAL));
+                filterArray.push(Filter.create("Id", subjects[0], Filter.Types.EQUAL));
             }
         }
         if (filterDate) {
@@ -81,7 +79,6 @@ export const GridPanelConfig: FC<configProps> = ({
             containerFilter: Query.containerFilter.allFolders,
             omittedColumns: ['SortOrder','Searchable','Type','Title','ContainerType','Workbook','IdPrefixedName'],
             includeTotalCount: true,
-            baseFilters: baseFilters,
             filterArray: filterArray,
             maxRows: 100,
         }
@@ -92,6 +89,8 @@ export const GridPanelConfig: FC<configProps> = ({
         <ServerContextProvider initialContext={serverContext}>
             <AppContextProvider>
                 <DefaultGridPanel
+                    schemaName={schemaName}
+                    queryName={queryName}
                     queryConfigs={queryConfigs}
                     input={input}
                     autoLoad

--- a/WNPRC_EHR/src/client/components/GridPanelConfig.tsx
+++ b/WNPRC_EHR/src/client/components/GridPanelConfig.tsx
@@ -6,8 +6,6 @@ import {
     withAppUser,
     AppContextProvider
 } from '@labkey/components';
-
-
 import { DefaultGridPanel } from "./DefaultGridPanel";
 import { configProps } from './grid_panel/configProps';
 import { labkeyActionSelectWithPromise } from '../query/helpers';
@@ -89,8 +87,6 @@ export const GridPanelConfig: FC<configProps> = ({
         <ServerContextProvider initialContext={serverContext}>
             <AppContextProvider>
                 <DefaultGridPanel
-                    schemaName={schemaName}
-                    queryName={queryName}
                     queryConfigs={queryConfigs}
                     input={input}
                     autoLoad

--- a/WNPRC_EHR/src/client/components/GridPanelConfig.tsx
+++ b/WNPRC_EHR/src/client/components/GridPanelConfig.tsx
@@ -41,10 +41,10 @@ export const GridPanelConfig: FC<configProps> = ({
 
         if (filterType !== "none") {
             if (filterType === "roomCage") {
-                const area = filterConfig.filters.area.split(',');
+                //const area = filterConfig.filters.area.split(',');
                 const room = filterConfig.filters.room.split(',');
                 const cage = filterConfig.filters.cage.split(',');
-                if (area[0] !== "") baseFilters.push(Filter.create("Id/curLocation/area", area, Filter.Types.EQUAL.getMultiValueFilter()));
+                //if (area[0] !== "") baseFilters.push(Filter.create("Id/curLocation/area", area, Filter.Types.EQUAL.getMultiValueFilter()));
                 if (room[0] !== "") baseFilters.push(Filter.create("Id/curLocation/room", room, Filter.Types.EQUAL.getMultiValueFilter()));
                 if (cage[0] !== "") baseFilters.push(Filter.create("Id/curLocation/cage", cage, Filter.Types.EQUAL.getMultiValueFilter()));
             } else if (filterType === "multiSubject") {

--- a/WNPRC_EHR/src/client/components/GridPanelConfig.tsx
+++ b/WNPRC_EHR/src/client/components/GridPanelConfig.tsx
@@ -40,7 +40,7 @@ export const GridPanelConfig: FC<configProps> = ({
 
 
         if (filterType !== "none") {
-            if (filterType === "roomCage") {
+            if (filterType === "roomCage" && filterConfig.filters.room !== null) {
                 //const area = filterConfig.filters.area.split(',');
                 const room = filterConfig.filters.room.split(',');
                 const cage = filterConfig.filters.cage.split(',');

--- a/WNPRC_EHR/src/client/components/grid_panel/configProps.ts
+++ b/WNPRC_EHR/src/client/components/grid_panel/configProps.ts
@@ -21,7 +21,6 @@ export interface configProps {
         };
     }];
     filterConfig?: {
-        subjects: any;
         date: any;
         filters: any;
     };


### PR DESCRIPTION
#### Rationale
A fix for the treatments location filter not working for some users with lower privileges and a printing button that users have been requesting for the new grid panels.

#### Related Pull Requests

#### Changes
Removed a property from the filterConfig object called subjects since it was not needed
Implemented a button that opens a printRows view for grid panels
Commented out area from the location filtering options