### PR TITLE
Add empty properties to fix sync for IntelliJ

### DIFF
--- a/docker/gradle.properties
+++ b/docker/gradle.properties
@@ -90,3 +90,7 @@ gsonVersion=2.8.9
 dockerhubUsername=
 dockerhubPassword=
 dockertokenpath=
+# define for use in `upSecondary`
+directory=
+# define for use in various commands
+dockerString=


### PR DESCRIPTION
#### Rationale
The docker `build.gradle` file requires certain properties to be set and current logic relies on the presence of these for a sync in IntelliJ to work properly.  This PR adds blank values for these properties so those who are not running the commands can still configure all gradle modules without extra command line arguments.

#### Related Pull Requests
* #432 

#### Changes
* Adding empty properties in `docker/build.gradle`
