### PR TITLE
Replace deprecated buildDir with layout.buildDirectory

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -26,7 +26,7 @@ import org.labkey.gradle.util.BuildUtils
 sourceSets {
     api {
         java { srcDirs = ['api-src'] }
-        output.resourcesDir = "${project.buildDir}/api-classes"
+        output.resourcesDir = project.layout.buildDirectory.file("api-classes")
     }
     main {
         java { srcDirs = ["src"] }


### PR DESCRIPTION
#### Rationale
In Gradle 8.3, the use of `project.buildDir` was [deprecated](https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir) in favor of `project.layout.buildDirectory`.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/185

#### Changes
* Replace deprecated buildDir with layout.buildDirectory
