### PR TITLE
Fixing problem with full history

### DIFF
--- a/WNPRC_EHR/resources/queries/study/wnprcFullHistory.sql
+++ b/WNPRC_EHR/resources/queries/study/wnprcFullHistory.sql
@@ -19,9 +19,9 @@ SELECT
     'Water Given (Total)' AS dataset,
     'watertotal' AS DataSetName,
     CASE
-         WHEN (remark IS NOT NULL AND remark !='') THEN
+         WHEN (remarksConcat IS NOT NULL AND remarksConcat !='') THEN
              ('Sum of all water given for the day.' || CHR(10)
-                 || remark)
+                 || remarksConcat)
              ELSE
             'Sum of all water given for the day.'
     END AS remark,


### PR DESCRIPTION
#### Rationale
- When adding remarks to the water total, the name of the remarks was changed to remarks concat, which did not match to the name used in the animal history.
- 
#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
