### PR TITLE
JavaScriptDisplayColumn no longer renders inline event handlers

### DIFF
--- a/WNPRC_EHR/resources/queries/study/foodDeprives.query.xml
+++ b/WNPRC_EHR/resources/queries/study/foodDeprives.query.xml
@@ -68,7 +68,7 @@
                             <className>org.labkey.api.data.JavaScriptDisplayColumnFactory</className>
                             &lt;!&ndash;<properties>
                                 <property name="dependency">ehr/window/ManageRecordWindow.js</property>
-                                <property name="javaScriptEvents">onclick="EHR.window.ManageRecordWindow.buttonHandler(${Id:jsString}, ${objectid:jsString}, ${queryName:jsString}, '${dataRegionName}');"</property>
+                                <property name="onclick">EHR.window.ManageRecordWindow.buttonHandler(${Id:jsString}, ${objectid:jsString}, ${queryName:jsString}, '${dataRegionName}');</property>
                             </properties>&ndash;&gt;
                         </displayColumnFactory>-->
                         <nullable>true</nullable>


### PR DESCRIPTION
#### Rationale
Adjust based on change to `JavaScriptDisplayColumn`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4970