### PR TITLE
Avoid exceptions uploading reports w/o Google Drive account

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/bc/BCReportManager.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/bc/BCReportManager.java
@@ -31,6 +31,11 @@ public class BCReportManager {
         WNPRC_EHRModule wnprc = ModuleLoader.getInstance().getModule(WNPRC_EHRModule.class);
         String id = wnprc.getGoogleDriveAccountId(studyContainer);
 
+        if (id == null) {
+            _log.info("No Google Drive account ID configured, not uploading reports");
+            return;
+        }
+
         try {
             DriveWrapper drive = GoogleDriveService.get().getDrive(id, user);
 


### PR DESCRIPTION
#### Rationale
Servers with the WNPRC_EHR module but without a configured Google Drive account hit an exception when the scheduled job fires:

```
ERROR Table                    2023-12-03T22:51:11,384 QuartzScheduler_Worker-8 : SQL Exception with SQLState: 42601
org.postgresql.util.PSQLException: ERROR: syntax error at or near ")"
  Position: 1168
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2713) ~[postgresql-42.6.0.jar:42.6.0]
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2401) ~[postgresql-42.6.0.jar:42.6.0]
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:368) ~[postgresql-42.6.0.jar:42.6.0]
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:498) ~[postgresql-42.6.0.jar:42.6.0]
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:415) ~[postgresql-42.6.0.jar:42.6.0]
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:335) ~[postgresql-42.6.0.jar:42.6.0]
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:321) ~[postgresql-42.6.0.jar:42.6.0]
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:297) ~[postgresql-42.6.0.jar:42.6.0]
	at org.postgresql.jdbc.PgStatement.executeQuery(PgStatement.java:246) ~[postgresql-42.6.0.jar:42.6.0]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingStatement.executeQuery(DelegatingStatement.java:316) ~[tomcat-dbcp.jar:9.0.78]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingStatement.executeQuery(DelegatingStatement.java:316) ~[tomcat-dbcp.jar:9.0.78]
	at org.labkey.api.data.dialect.StatementWrapper.executeQuery(StatementWrapper.java:1834) ~[api-23.7.8.jar:?]
	at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.executeQuery(SqlExecutingSelector.java:496) [api-23.7.8.jar:?]
	at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.handleResultSet(SqlExecutingSelector.java:408) [api-23.7.8.jar:?]
	at org.labkey.api.data.SqlExecutingSelector.getResultSet(SqlExecutingSelector.java:208) [api-23.7.8.jar:?]
	at org.labkey.api.data.SqlExecutingSelector.getResultSet(SqlExecutingSelector.java:250) [api-23.7.8.jar:?]
	at org.labkey.query.QueryServiceImpl$SelectBuilderImpl.select(QueryServiceImpl.java:2754) [query-23.7.8.jar:?]
	at org.labkey.api.query.QueryService$SelectBuilder.select(QueryService.java:665) [api-23.7.8.jar:?]
	at org.labkey.api.query.QueryHelper.select(QueryHelper.java:219) [api-23.7.8.jar:?]
	at org.labkey.api.query.QueryHelper.select(QueryHelper.java:180) [api-23.7.8.jar:?]
	at org.labkey.dbutils.api.SimpleQuery.getResults(SimpleQuery.java:193) [DBUtils_api-23.7.8.jar:?]
	at org.labkey.dbutils.api.SimpleQueryFactory.selectRows(SimpleQueryFactory.java:32) [DBUtils_api-23.7.8.jar:?]
	at org.labkey.googledrive.GoogleDriveServiceImpl.getCredentialJSON(GoogleDriveServiceImpl.java:69) [GoogleDrive-23.7.8.jar:?]
	at org.labkey.googledrive.GoogleDriveServiceImpl.getCredential(GoogleDriveServiceImpl.java:84) [GoogleDrive-23.7.8.jar:?]
	at org.labkey.googledrive.GoogleDriveServiceImpl.getRawDrive(GoogleDriveServiceImpl.java:56) [GoogleDrive-23.7.8.jar:?]
	at org.labkey.googledrive.GoogleDriveServiceImpl.getDrive(GoogleDriveServiceImpl.java:103) [GoogleDrive-23.7.8.jar:?]
	at org.labkey.wnprc_ehr.bc.BCReportManager.uploadReports(BCReportManager.java:35) [WNPRC_EHR-23.7.8.jar:?]
	at org.labkey.wnprc_ehr.bc.BCReportRunner.execute(BCReportRunner.java:51) [WNPRC_EHR-23.7.8.jar:?]
	at org.quartz.core.JobRunShell.run(JobRunShell.java:202) [quartz-2.3.2.jar:?]
	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573) [quartz-2.3.2.jar:?]
```

#### Changes
* Don't try uploading reports if there's no target Google Drive configured