### PR TITLE
Update Pregnancy Report Sort Order

### DIFF
--- a/WNPRC_EHR/resources/queries/study/PregnancyInfo/pregnancies_all.qview.xml
+++ b/WNPRC_EHR/resources/queries/study/PregnancyInfo/pregnancies_all.qview.xml
@@ -20,4 +20,7 @@
         <column name="outcome_date"/>
         <column name="infantid"/>
     </columns>
+    <sorts>
+        <sort column="date_conception" descending="true"/>
+    </sorts>
 </customView>


### PR DESCRIPTION
#### Rationale
Change the sorting order of the animal history pregnancy report to go by conception date, descending.

#### Related Pull Requests

#### Changes
Descending sort added to pregnancies all qview.xml 