### PR TITLE
Use shared version property for commons text

### DIFF
--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "org.apache.commons:commons-text:1.10.0",
+            "org.apache.commons:commons-text:${commonsTextVersion}",
             "Commons Text",
             "Apache",
             "https://commons.apache.org/proper/commons-text/",


### PR DESCRIPTION
#### Rationale
Keep commons text dependency in-sync