### PR TITLE
Force version consistency for annotations and reflections

### DIFF
--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "org.reflections:reflections:0.9.10",
+            "org.reflections:reflections:${reflectionsVersion}",
             "Reflections",
             "Reflections",
             "https://github.com/ronmamo/reflections",


### PR DESCRIPTION
#### Rationale
A recent dependency update in `tcrdb` caused some version discrepancies.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/710

#### Changes
* Use property to specify reflections version
