### PR TITLE
Migrate inline javascript event handlers

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/calendars/OnCallCalendar.jsp
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/calendars/OnCallCalendar.jsp
@@ -74,11 +74,15 @@
                 <div class="row">
                     <div class="col-sm-2">
                         <label for="startDate">Start Date</label>
-                        <input type="text" onfocus="setDateOnFocus(this)" onblur="setPlaceholderOnBlur(this)" class="form-control" id="startDate" placeholder="">
+                        <input type="text" class="form-control" id="startDate" placeholder="">
+                        <% addHandler("startDate", "focus", "setDateOnFocus(this)");%>
+                        <% addHandler("startDate", "blur", "setPlaceholderOnBlur(this)");%>
                     </div>
                     <div class="col-sm-2">
                         <label for="endDate">End Date</label>
-                        <input type="text" onfocus="setDateOnFocus(this)" onblur="setPlaceholderOnBlur(this)" class="form-control" id="endDate" placeholder="">
+                        <input type="text" class="form-control" id="endDate" placeholder="">
+                        <% addHandler("endDate", "focus", "setDateOnFocus(this)");%>
+                        <% addHandler("endDate", "blur", "setPlaceholderOnBlur(this)");%>
                     </div>
                 </div>
             </div>

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/husbandry/WaterCalendar.jsp
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/husbandry/WaterCalendar.jsp
@@ -1208,9 +1208,20 @@
                                     let volume = Ext4.util.Format.htmlEncode(errorObject.volume);
                                     let date = Ext4.util.Format.htmlEncode(errorObject.date);
                                     returnMessage += "<div id='waterException" + i +"'>There is another waterAmount on "+date+" for the volume of "+volume+" " +
-                                            " <button onclick=\"updateWaterAmount('"+clientObjectId+"')\">Update</button> " +
-                                            "<button onclick=\"deleteWaterAmount(null, null,'"+clientObjectId+"','waterException" + i +"')\">Delete</button><br></div>";
+                                            " <button id='water-updt-btn'>Update</button> " +
+                                            "<button id='water-dlt-btn'>Delete</button><br></div>";
 
+                                    setTimeout(function() {
+                                        // Attach the onclick handler, this will be executed after 100 milliseconds, similar to Ext4.defer.
+                                        LABKEY.Utils.attachEventHandler("water-updt-btn", "click", function () {
+                                            return updateWaterAmount(clientObjectId);
+                                        });
+
+                                        LABKEY.Utils.attachEventHandler("water-dlt-btn", "click", function () {
+                                            return deleteWaterAmount(null, null, clientObjectId, "waterException" + i);
+                                        });
+
+                                    }, 100);
                                 }
 
                             }

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/husbandry/WaterCalendar.jsp
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/husbandry/WaterCalendar.jsp
@@ -1208,21 +1208,12 @@
                                     let volume = Ext4.util.Format.htmlEncode(errorObject.volume);
                                     let date = Ext4.util.Format.htmlEncode(errorObject.date);
                                     returnMessage += "<div id='waterException" + i +"'>There is another waterAmount on "+date+" for the volume of "+volume+" " +
-                                            " <button id='water-updt-btn'>Update</button> " +
-                                            "<button id='water-dlt-btn'>Delete</button><br></div>";
-
-                                    setTimeout(function() {
-                                        // Attach the onclick handler, this will be executed after 100 milliseconds, similar to Ext4.defer.
-                                        LABKEY.Utils.attachEventHandler("water-updt-btn", "click", function () {
-                                            return updateWaterAmount(clientObjectId);
-                                        });
-
-                                        LABKEY.Utils.attachEventHandler("water-dlt-btn", "click", function () {
-                                            return deleteWaterAmount(null, null, clientObjectId, "waterException" + i);
-                                        });
-
-                                    }, 100);
+                                            " <button class='water-updt-btn' data-clientObjectId='" + clientObjectId + "'>Update</button> " +
+                                            "<button class='water-dlt-btn' data-clientObjectId='" + clientObjectId + "' data-index='" + i +"'>Delete</button><br></div>";
                                 }
+
+                                LABKEY.Utils.attachEventHandlerForQuerySelector('BUTTON.water-updt-btn','click',function(){return updateWaterAmount(this.attributes.getNamedItem('data-clientObjectId').value);});
+                                LABKEY.Utils.attachEventHandlerForQuerySelector('BUTTON.water-dlt-btn','click',function(){return deleteWaterAmount(null, null, this.attributes.getNamedItem('data-clientObjectId').value, "waterException" + this.attributes.getNamedItem('data-index').value)});
 
                             }
                             document.getElementById("modelServerResponse").innerHTML = "<p>"+returnMessage+"</p>";

--- a/WebUtils/src/org/labkey/webutils/view/knockout_components/lk-table.jsp
+++ b/WebUtils/src/org/labkey/webutils/view/knockout_components/lk-table.jsp
@@ -70,7 +70,8 @@
             <!-- ko foreach2: {data: $parent.table.rows } -->
             <tr data-bind="css: { 'clickable': $component.rowsAreClickable, 'warning': warn, 'danger': err}, visible: !isHidden(), style: {background-color: isSelected() ? $component.rowBackgroundColorClicked : '', 'cursor' : $component.cursor} ">
                 <!-- ko if: $component.rowsAreSelectable -->
-                <td onclick="event.stopPropagation();"> <%-- prevent click from propagating to the row. --%>
+                <td id="chk-btn"> <%-- prevent click from propagating to the row. --%>
+                    <% addHandler("chk-btn", "click", "event.stopPropagation()"); %>
                     <input type="checkbox" data-bind="checked: isSelected" >
                 </td>
                 <!-- /ko -->


### PR DESCRIPTION
#### Rationale
A strict (no 'unsafe-inline' directive) CSP forbids all inline events. Instead, events must be attached via JavaScript inside a properly nonced script tag

#### Changes
* watercalendar.jsp
* OnCallCalendar.jsp
* lk-table.jsp