### PR TITLE
Ticket 50255: Users unable to release animals from behavior assignments

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/service/dataentry/BehaviorDataEntryService.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/service/dataentry/BehaviorDataEntryService.java
@@ -107,7 +107,7 @@ public class BehaviorDataEntryService extends SecurityEscalatedService
 
             rowMap.put("lsid", assignment.getString("lsid"));
             rowMap.put("Id", assignment.getString("id"));
-            rowMap.put("project", assignment.getString("project"));
+            rowMap.put("project", assignment.getInt("project"));
             rowMap.put("endDate", releaseDate);
 
             rowsToUpdate.add(rowMap);


### PR DESCRIPTION
#### Rationale
JSON type mismatch causing this [issue](https://www.labkey.org/WNPRC/support%20tickets/issues-details.view?issueId=50255). Previous JSON library more lenient with type checking.

#### Changes
* Project field is an int so get correct type
