### PR TITLE
Finish test related query validation

### DIFF
--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -488,6 +488,7 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         SelectRowsCommand selectCmd = new SelectRowsCommand("ehr_billing", "chargeableItems");
         selectCmd.setColumns(Arrays.asList("rowId, name"));
         selectCmd.addFilter(new Filter("name", chargeName));
+        
         SelectRowsResponse response = selectCmd.execute(cn, getBillingContainerPath());
         return (Integer) response.getRows().get(0).get("rowId");
     }


### PR DESCRIPTION
#### Rationale
This is the last of the refactors for test related query validation failures. There are still a handful of queries failing that are failing on the production server that will need approval to delete or fix. 

#### Changes
* Reorder some of the initialization to have the required schemas and columns for query validation
* Setup billing and ehr_lookups before query validation
