### PR TITLE
Protocol count validation for Macaques

### DIFF
--- a/WNPRC_EHR/resources/queries/study/assignment.js
+++ b/WNPRC_EHR/resources/queries/study/assignment.js
@@ -65,15 +65,14 @@ function onUpsert(helper, scriptErrors, row, oldRow){
     }
 
     //check number of allowed animals at assign/approve time
-    if (!helper.isETL() && !helper.isQuickValidation() && helper.doStandardProtocolCountValidation() &&
+    if (!helper.isETL() && !helper.isQuickValidation() &&
             //this is designed to always perform the check on imports, but also updates where the Id was changed
             !(oldRow && oldRow.Id && oldRow.Id==row.Id) &&
             row.Id && row.project && row.date
     ){
         var assignmentsInTransaction = helper.getProperty('assignmentsInTransaction');
         assignmentsInTransaction = assignmentsInTransaction || [];
-
-        var msgs = helper.getJavaHelper().verifyProtocolCounts(row.Id, row.project, assignmentsInTransaction);
+        var msgs = WNPRC.Utils.getJavaHelper().verifyProtocolCounts(row.Id, row.project, assignmentsInTransaction);
         if (msgs){
             msgs = msgs.split("<>");
             for (var i=0;i<msgs.length;i++){

--- a/WNPRC_EHR/resources/queries/study/protocolTotalAnimalsBySpecies.query.xml
+++ b/WNPRC_EHR/resources/queries/study/protocolTotalAnimalsBySpecies.query.xml
@@ -1,0 +1,34 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="protocolTotalAnimalsBySpecies" tableDbType="NOT_IN_DB">
+                <tableTitle>Total Animals Assigned To Each Protocol, By Species</tableTitle>
+                <columns>
+                    <column columnName="protocol">
+                        <isKeyField>true</isKeyField>
+                        <fk>
+                            <fkDbSchema>ehr</fkDbSchema>
+                            <fkTable>protocol</fkTable>
+                            <fkColumnName>protocol</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="Species">
+                        <fk>
+                            <fkDbSchema>ehr_lookups</fkDbSchema>
+                            <fkTable>species</fkTable>
+                            <fkColumnName>common</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="TotalAnimals">
+                        <url>/query/executeQuery.view?schemaName=ehr&amp;
+                            query.queryName=protocolAnimals&amp;
+                            query.protocol~eq=${protocol}&amp;
+                            query.species~eq=${species}&amp;
+                        </url>
+                    </column>
+                </columns>
+                <titleColumn>TotalAnimals</titleColumn>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/WNPRC_EHR/resources/queries/study/protocolTotalAnimalsBySpecies.sql
+++ b/WNPRC_EHR/resources/queries/study/protocolTotalAnimalsBySpecies.sql
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2011-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+SELECT
+
+    p.protocol,
+    (select approve from ehr.protocol where p.protocol = protocol) as approve,
+    p.species,
+    pc.allowed,
+    p.TotalAnimals,
+    CONVERT(pc.allowed - p.TotalAnimals, INTEGER) as TotalRemaining,
+    CASE WHEN (pc.allowed IS NULL or pc.allowed = 0) THEN NULL ELSE round(cast(p.TotalAnimals as float) / cast(pc.allowed as float) * 100, 1) END as PercentUsed,
+    p.Animals
+
+FROM
+    (
+        SELECT
+            coalesce(p.protocol, pa.protocol) as protocol,
+            p.species as species,
+            group_concat(DISTINCT pa.id) as Animals,
+            CONVERT(Count(pa.id), INTEGER) AS TotalAnimals
+
+        FROM ehr.protocol_counts p
+                 LEFT OUTER JOIN ehr.protocolAnimals pa ON (p.protocol = pa.protocol and p.species = pa.species)
+
+        WHERE p.species != 'Macaque'
+        GROUP BY coalesce(p.protocol, pa.protocol), p.species
+
+        UNION
+
+        /*
+         * Calculate the macaque totals as well, as the sum of Cynos and Rhesus
+         */
+
+        SELECT
+            coalesce(p.protocol, pa.protocol) as protocol,
+            'Macaque' as species,
+            group_concat(DISTINCT pa.id) as Animals,
+            CONVERT(Count(pa.id), INTEGER) AS TotalAnimals
+
+        FROM ehr.protocol_counts p
+            LEFT OUTER JOIN ehr.protocolAnimals pa ON (p.protocol = pa.protocol and p.species = pa.species)
+
+
+        WHERE pa.species = 'Cynomolgus' OR pa.species = 'Rhesus'
+
+          AND EXISTS (  -- Check if 'macaque' exists for protocol
+            SELECT 1
+            FROM ehr.protocol_counts pc2
+            WHERE pc2.protocol = p.protocol AND pc2.species = 'Macaque'
+            )
+        GROUP BY coalesce(p.protocol, pa.protocol), p.species
+
+
+    ) p
+
+        LEFT JOIN ehr.protocol_counts pc ON (p.protocol = pc.protocol AND pc.species = p.species)
+
+WHERE p.species IS NOT NULL
+
+
+UNION ALL
+
+
+SELECT
+    p.protocol,
+    (select approve from ehr.protocol where p.protocol = protocol) as approve,
+    'All Species' as species,
+    p.maxAnimals as allowed,
+    CONVERT(Count(pa.id), INTEGER) AS TotalAnimals,
+    p.maxAnimals - Count(pa.id) as TotalRemaining,
+    CASE WHEN (p.maxAnimals IS NULL or p.maxAnimals = 0) THEN NULL ELSE round(cast(Count(pa.id) as float) / cast(p.maxAnimals as float) * 100, 1) END as PercentUsed,
+    group_concat(distinct pa.Id) as animals
+
+FROM ehr.protocol p
+         LEFT OUTER JOIN ehr.protocolAnimals pa ON (p.protocol = pa.protocol)
+WHERE p.maxAnimals IS NOT NULL
+GROUP BY p.protocol, p.maxAnimals

--- a/WNPRC_EHR/resources/queries/study/protocolTotalAnimalsBySpecies.sql
+++ b/WNPRC_EHR/resources/queries/study/protocolTotalAnimalsBySpecies.sql
@@ -58,7 +58,7 @@ FROM
 
         LEFT JOIN ehr.protocol_counts pc ON (p.protocol = pc.protocol AND pc.species = p.species)
 
-WHERE p.species IS NOT NULL
+WHERE p.species IS NOT NULL and pc.allowed IS NOT NULL
 
 
 UNION ALL

--- a/WNPRC_EHR/resources/scripts/wnprc_ehr/wnprc_triggers.js
+++ b/WNPRC_EHR/resources/scripts/wnprc_ehr/wnprc_triggers.js
@@ -22,6 +22,7 @@ exports.init = function (EHR) {
 
     EHR.Server.TriggerManager.registerHandler(EHR.Server.TriggerManager.Events.INIT, function (event, helper, EHR) {
         EHR.Server.TriggerManager.unregisterAllHandlersForQueryNameAndEvent('study', 'blood', EHR.Server.TriggerManager.Events.BEFORE_UPSERT);
+        EHR.Server.TriggerManager.unregisterAllHandlersForQueryNameAndEvent('study', 'assignment', EHR.Server.TriggerManager.Events.BEFORE_UPSERT);
         setStudyBloodBeforeUpsertTrigger();
     });
 

--- a/WNPRC_EHR/resources/web/ehr/ext3/ExtContainers.js
+++ b/WNPRC_EHR/resources/web/ehr/ext3/ExtContainers.js
@@ -2265,7 +2265,7 @@ EHR.ext.AssignmentAbstractPanel = Ext.extend(EHR.ext.AbstractPanel, {
                 timeout: 0,
                 linkTarget: '_blank',
                 renderTo: this.placeForQwp.body.id,
-                schemaName: 'ehr',
+                schemaName: 'study',
                 queryName: 'protocolTotalAnimalsBySpecies',
                 //viewName: 'With Animals',
                 scope: this,

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
@@ -2438,7 +2438,7 @@ public class TriggerScriptHelper {
         }
 
         //find the total animals previously used by this protocols/species
-        TableInfo ti = QueryService.get().getUserSchema(user, container, "ehr").getTable("protocolTotalAnimalsBySpecies");
+        TableInfo ti = QueryService.get().getUserSchema(user, container, "study").getTable("protocolTotalAnimalsBySpecies");
         String animalSpecies = ar.getSpecies();
         SimpleFilter filter;
         if (("Rhesus".equals(animalSpecies) || "Cynomolgus".equals(animalSpecies)))

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
@@ -82,6 +82,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -2420,6 +2421,10 @@ public class TriggerScriptHelper {
 
     public String verifyProtocolCounts(final String id, Integer project, final List<Map<String, Object>> recordsInTransaction)
     {
+        final String RHESUS_SPECIES = "Rhesus";
+        final String CYNOMOLGUS_SPECIES = "Cynomolgus";
+        final String MACAQUE_SPECIES = "Macaque";
+        final String ALL_SPECIES = "All Species";
         if (id == null)
         {
             return null;
@@ -2441,17 +2446,16 @@ public class TriggerScriptHelper {
         TableInfo ti = QueryService.get().getUserSchema(user, container, "study").getTable("protocolTotalAnimalsBySpecies");
         String animalSpecies = ar.getSpecies();
         SimpleFilter filter;
-        if (("Rhesus".equals(animalSpecies) || "Cynomolgus".equals(animalSpecies)))
+        if ((RHESUS_SPECIES.equals(animalSpecies) || CYNOMOLGUS_SPECIES.equals(animalSpecies)))
         {
-            filter = new SimpleFilter(FieldKey.fromString("species"), PageFlowUtil.set(animalSpecies, "All Species", "Macaque"), CompareType.IN);
+            filter = new SimpleFilter(FieldKey.fromString("species"), PageFlowUtil.set(animalSpecies, ALL_SPECIES, MACAQUE_SPECIES), CompareType.IN);
         } else
         {
-            filter = new SimpleFilter(FieldKey.fromString("species"), PageFlowUtil.set(animalSpecies, "All Species"), CompareType.IN);
+            filter = new SimpleFilter(FieldKey.fromString("species"), PageFlowUtil.set(animalSpecies, ALL_SPECIES), CompareType.IN);
         }
         filter.addCondition(FieldKey.fromString("protocol"), protocol);
         TableSelector ts = new TableSelector(ti, filter, null);
         final List<String> errors = new ArrayList<>();
-        final String ALL_SPECIES = "All Species";
         final boolean[] noSpeciesListedOnProtocol = {true};
         ts.forEach(new Selector.ForEachBlock<ResultSet>()
         {
@@ -2489,7 +2493,7 @@ public class TriggerScriptHelper {
                         AnimalRecord ar = EHRDemographicsService.get().getAnimal(container, id);
 
                         //we don't want to exit the animal count if ar.species() is cyno or rhesus and the protocol's species value is macaque.
-                        if (!ALL_SPECIES.equals(species) && !("Rhesus".equals(ar.getSpecies()) || "Cynomolgus".equals(ar.getSpecies()) && "Macaque".equals(species)))
+                        if (!ALL_SPECIES.equals(species) && !(RHESUS_SPECIES.equals(ar.getSpecies()) || CYNOMOLGUS_SPECIES.equals(ar.getSpecies()) && MACAQUE_SPECIES.equals(species)))
                         {
                             //find species
                             if (ar.getSpecies() == null || !species.equals(ar.getSpecies()))

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/TriggerScriptHelper.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 import org.labkey.api.announcements.api.Announcement;
 import org.labkey.api.announcements.api.AnnouncementService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -27,6 +28,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.ehr.EHRDemographicsService;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.ehr.EHRService;
+import org.labkey.api.ehr.demographics.AnimalRecord;
 import org.labkey.api.ehr.security.EHRDataAdminPermission;
 import org.labkey.api.ehr.security.EHRSecurityEscalator;
 import org.labkey.api.ldk.notification.NotificationService;
@@ -68,6 +70,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
@@ -76,6 +79,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -2413,4 +2417,110 @@ public class TriggerScriptHelper {
     }
 
     public boolean isDataAdmin(){return getContainer().hasPermission(getUser(), EHRDataAdminPermission.class);}
+
+    public String verifyProtocolCounts(final String id, Integer project, final List<Map<String, Object>> recordsInTransaction)
+    {
+        if (id == null)
+        {
+            return null;
+        }
+
+        AnimalRecord ar = EHRDemographicsService.get().getAnimal(container, id);
+        if (ar.getSpecies() == null)
+        {
+            return "Unknown species: " + id;
+        }
+
+        final String protocol = EHRService.get().getProtocolForProject(container, user, project);
+        if (protocol == null)
+        {
+            return "Unable to find protocol associated with project: " + project;
+        }
+
+        //find the total animals previously used by this protocols/species
+        TableInfo ti = QueryService.get().getUserSchema(user, container, "ehr").getTable("protocolTotalAnimalsBySpecies");
+        String animalSpecies = ar.getSpecies();
+        SimpleFilter filter;
+        if (("Rhesus".equals(animalSpecies) || "Cynomolgus".equals(animalSpecies)))
+        {
+            filter = new SimpleFilter(FieldKey.fromString("species"), PageFlowUtil.set(animalSpecies, "All Species", "Macaque"), CompareType.IN);
+        } else
+        {
+            filter = new SimpleFilter(FieldKey.fromString("species"), PageFlowUtil.set(animalSpecies, "All Species"), CompareType.IN);
+        }
+        filter.addCondition(FieldKey.fromString("protocol"), protocol);
+        TableSelector ts = new TableSelector(ti, filter, null);
+        final List<String> errors = new ArrayList<>();
+        final String ALL_SPECIES = "All Species";
+        final boolean[] noSpeciesListedOnProtocol = {true};
+        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        {
+            @Override
+            public void exec(ResultSet rs) throws SQLException
+            {
+                int totalAllowed = rs.getInt("allowed");
+                boolean totalAllowedNull = rs.wasNull();
+                String species = rs.getString("Species");
+                Set<String> animals = new CaseInsensitiveHashSet();
+                String animalString = rs.getString("Animals");
+                if (animalString != null)
+                {
+                    animals.addAll(Arrays.asList(StringUtils.split(animalString, ",")));
+                }
+
+                animals.add(id);
+
+                if (recordsInTransaction != null && recordsInTransaction.size() > 0)
+                {
+                    for (Map<String, Object> r : recordsInTransaction)
+                    {
+                        String id = (String)r.get("Id");
+                        Number project = (Number)r.get("project");
+                        if (id == null || project == null)
+                        {
+                            continue;
+                        }
+
+                        String rowProtocol = EHRService.get().getProtocolForProject(container, user, project.intValue());
+                        if (rowProtocol == null || !rowProtocol.equals(protocol))
+                        {
+                            continue;
+                        }
+                        AnimalRecord ar = EHRDemographicsService.get().getAnimal(container, id);
+
+                        //we don't want to exit the animal count if ar.species() is cyno or rhesus and the protocol's species value is macaque.
+                        if (!ALL_SPECIES.equals(species) && !("Rhesus".equals(ar.getSpecies()) || "Cynomolgus".equals(ar.getSpecies()) && "Macaque".equals(species)))
+                        {
+                            //find species
+                            if (ar.getSpecies() == null || !species.equals(ar.getSpecies()))
+                            {
+                                continue;
+                            }
+                        }
+
+                        animals.add(id);
+                        if (ar.getSpecies().equals(species))
+                        {
+                            noSpeciesListedOnProtocol[0] = false;
+                        }
+                    }
+                }
+
+
+
+                int remaining = totalAllowed - animals.size();
+                if (remaining < 0)
+                {
+                    errors.add("There are not enough spaces on protocol: " + protocol + ". Allowed: " + (totalAllowedNull ? "none": totalAllowed) + ", used: " + animals.size());
+                }
+            }
+        });
+
+        if (noSpeciesListedOnProtocol[0])
+        {
+            errors.add("Species not allowed on protocol: " + protocol);
+        }
+
+        return StringUtils.join(errors, "<>");
+    }
 }

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -280,7 +280,7 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         initTest.setupAnimalRequests();
 
         initTest.checkUpdateProgramIncomeAccount();
-        //initTest.deathNotificationSetup();
+        initTest.deathNotificationSetup();
     }
 
     private void billingSetup() throws Exception
@@ -413,6 +413,7 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
                 {MORE_ANIMAL_IDS[1], "Rhesus", (new Date()).toString(), getMale(), new Date(), "Alive", UUID.randomUUID().toString()},
                 {MORE_ANIMAL_IDS[2], "Rhesus", (new Date()).toString(), getFemale(), new Date(), "Alive", UUID.randomUUID().toString()},
                 {MORE_ANIMAL_IDS[3], "Rhesus", (new Date()).toString(), getMale(), new Date(), "Alive", UUID.randomUUID().toString()},
+                {MORE_ANIMAL_IDS[4], "Rhesus", (new Date()).toString(), getMale(), new Date(), "Alive", UUID.randomUUID().toString()}
         };
         insertCommand = getApiHelper().prepareInsertCommand("study", "demographics", "lsid", fields, data);
         getApiHelper().deleteAllRecords("study", "demographics", new Filter("Id", StringUtils.join(MORE_ANIMAL_IDS, ";"), Filter.Operator.IN));


### PR DESCRIPTION
#### Rationale
This PR creates a new WNPRC specific verifyProtocolCounts function similar to the EHR version but accounting for Macaque species validation. The EHR assignment trigger is unregistered in favor of a WNPRC trigger calling the new verifyProtocolCounts function.

#### Related Pull Requests
* Replacing this PR https://github.com/LabKey/ehrModules/pull/791
* https://github.com/LabKey/ehrModules/pull/795

#### Changes
* Add the verifyProtocolCounts function from PR referenced above
* Unregister EHR assignment trigger
* Update WNPRC assignment trigger to use WNPRC verifyProtocolCounts
* Copy protocolTotalAnimalsBySpecies.sql from the above PR
