### PR TITLE
Update entryPoints.js to use permissionClasses instead of permission property

### DIFF
--- a/WNPRC_EHR/src/client/entryPoints.js
+++ b/WNPRC_EHR/src/client/entryPoints.js
@@ -29,7 +29,6 @@ module.exports = {
     },{
         name: 'abstract',
         title: 'Abstract',
-        permission: 'read',
         path: './src/client/abstract/base',
         generateLib: true
     },{
@@ -40,7 +39,6 @@ module.exports = {
     },{
         name: 'research_ultrasounds_webpart',
         title: 'Research Ultrasounds Webpart',
-        permission: 'read',
         path: './src/client/researchUltrasounds/webpart',
         generateLib: true
     },{

--- a/WNPRC_EHR/src/client/entryPoints.js
+++ b/WNPRC_EHR/src/client/entryPoints.js
@@ -2,29 +2,29 @@ module.exports = {
     apps: [{
         name: 'grid_panel',
         title: 'Default Grid',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/components/grid_panel'
     },{
         name: 'grid_panel_webpart',
         title: 'Default Grid Webpart',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/components/grid_panel/webpart',
         generateLib: true
     },{
         name: 'breeding',
         title: 'Pregnancies',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/breeding'
     },{
         name: 'breeding_webpart',
         title: 'Pregnancies Webpart',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/breeding/webpart',
         generateLib: true
     },{
         name: 'feeding',
         title: 'Feeding',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/feeding/base'
     },{
         name: 'abstract',
@@ -35,7 +35,7 @@ module.exports = {
     },{
         name: 'research_ultrasounds',
         title: 'Research Ultrasounds',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/researchUltrasounds'
     },{
         name: 'research_ultrasounds_webpart',
@@ -46,7 +46,8 @@ module.exports = {
     },{
         name: 'weight',
         title: 'Weight',
-        permission: 'login',
+        // permission: 'login',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/weight'
     }]
 };

--- a/WNPRC_Purchasing/src/client/entryPoints.js
+++ b/WNPRC_Purchasing/src/client/entryPoints.js
@@ -8,7 +8,7 @@ module.exports = {
         {
             name: 'RequestEntry',
             title: 'WNPRC Purchasing',
-            permission: 'insert',
+            permissionClasses: ['org.labkey.api.security.permissions.InsertPermission'],
             path: './src/client/RequestEntry',
         },
     ],

--- a/WNPRC_Virology/src/client/entryPoints.js
+++ b/WNPRC_Virology/src/client/entryPoints.js
@@ -3,7 +3,7 @@ module.exports = {
         {
             name: 'DropdownSelect',
             title: 'Virology Frontend Page',
-            permission: 'insert',
+            permissionClasses: ['org.labkey.api.security.permissions.InsertPermission'],
             path: './src/client/AccountsForm',
             generateLib: true
         },


### PR DESCRIPTION
#### Rationale
We are deprecating the `<permissions>` properties for the view.xml files. This PR migrates those usages to `<permissionClasses>`.

#### Changes
- Update entryPoints.js to use permissionClasses instead of permission property
- Remove entryPoints.js permission props for generateLib since they don't apply for libs
