### PR TITLE
Migrate <permission name="login"/> to <requiresLogin/>

### DIFF
--- a/AnimalRequests/resources/views/app.view.xml
+++ b/AnimalRequests/resources/views/app.view.xml
@@ -1,7 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" frame="none" title="Animal Request Form">
-    <permissions>
-        <permission name="login"/>
-    </permissions>
+    <requiresLogin/>
     <dependencies>
         <dependency path="animalrequests/gen/app.js"/>
     </dependencies>


### PR DESCRIPTION
#### Rationale
`<permissions>` element is deprecated and soon to be removed