### PR TITLE
Fix WNPRC test failure "specified query 'datasets' does not exist in schema 'study'"

### DIFF
--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -268,6 +268,8 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
 
         initTest.initCreatedProject();
 
+        initTest.goToPIPortal();
+        initTest.addBillingPublicWebParts();
         initTest.uploadBillingDataAndVerify();
 
         // Blood triggers are dependent on weights, so the blood sample data has to be imported after weights. Doing this after
@@ -308,9 +310,6 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         initTest._containerHelper.enableModules(Arrays.asList("WNPRC_BillingPublic"));
 
         initTest.createWNPRCBillingPublicLinkedSchema();
-
-        goToPIPortal();
-        initTest.addBillingPublicWebParts();
     }
 
     private void loadEHRBillingExtensibleCols()


### PR DESCRIPTION
#### Rationale
WNPRC_EHRTest failing during setup with error:
The specified query 'datasets' does not exist in schema 'study' while adding the webpart “WNPRC Billing PI Portal”
	at org.labkey.test.util.PortalHelper.doInAdminMode(PortalHelper.java:272)
	at org.labkey.test.util.PortalHelper.addWebPart(PortalHelper.java:293)
	at org.labkey.test.util.PortalHelper.addWebPart(PortalHelper.java:311)
	at org.labkey.test.tests.wnprc_ehr.WNPRC_EHRTest.addFinanceRelatedWebParts(WNPRC_EHRTest.java:296)
	at org.labkey.test.tests.wnprc_ehr.WNPRC_EHRTest.doSetup(WNPRC_EHRTest.java:200)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Change the sequence of some of the Billing setup so that query validation can successfully validate and required datasets are present.
