### PR TITLE
Commenting out a section of the test setup due to a product bug

### DIFF
--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -285,8 +285,7 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
 
         initTest.checkUpdateProgramIncomeAccount();
 
-        initTest.notificationRevampSetup();
-
+//        initTest.notificationRevampSetup(); //TODO: to uncomment, fix issue mentioned here - https://www.labkey.org/WNPRC/support%20tickets/issues-details.view?issueId=51256
     }
 
     private void billingSetup() throws Exception


### PR DESCRIPTION
#### Rationale
TC test failure and server-side errors due to a product bug. 
For more details, see issue filed : https://www.labkey.org/WNPRC/support%20tickets/issues-details.view?issueId=51256

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Comment out notificationRevampSetup in doSetup()