### PR TITLE
Comment out failing test due to a product bug

### DIFF
--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -4058,7 +4058,8 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         log("Completed notification revamp test: Prenatal Death Notification Revamp");
     }
 
-    @Test
+    //TODO: is this a setup or a test? its being called from doSetup() and also has a @Test annotation.
+    //@Test
     public void notificationRevampSetup() throws UnhandledAlertException, IOException, CommandException {
         // Set up.
         log("Starting notificationRevampSetup()");
@@ -4109,6 +4110,7 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         myReusableFunctions.insertValueIntoBloodBilledByDataset("spi", "SPI");
 
         // Runs tests.
+        // TODO: separate these tests out so they run individually and keep above as part of the setup for below tests
         notificationRevampTestBloodDrawsTodayAll();
         notificationRevampTestBloodDrawsTodayAnimalCare();
         notificationRevampTestBloodDrawsTodayVetStaff();


### PR DESCRIPTION
#### Rationale
TC test failure and server-side errors due to a product bug.
For more details, see issue filed : https://www.labkey.org/WNPRC/support%20tickets/issues-details.view?issueId=51256

This issue was related to running notificationRevampSetup() as a test. In the related PR below, it is also part of the doSetup() step.

#### Related Pull Requests
* https://github.com/LabKey/wnprc-modules/pull/655

#### Changes
* Comment out failing test due to a product bug