### PR TITLE
Remove link for "Guidelines for Protocols" from Misc Pages

### DIFF
--- a/WNPRC_EHR/resources/views/wnprcUnits.html
+++ b/WNPRC_EHR/resources/views/wnprcUnits.html
@@ -160,7 +160,6 @@ function createNavMenu()
             items: [
                 {name: 'Change WNPRC Password', url: 'https://www.mynetid.wisc.edu/recover/pwdreset'},
                 {name: 'Employee List', url: '<%=contextPath%>' + '/WNPRC/EHR/query-executeQuery.view?schemaName=study&query.queryName=EmployeeList'},
-                {name: 'Guidelines for Protocols', url: '<%=contextPath%>' + '/WNPRC/WNPRC_Units/Animal_Services/Compliance_Training/Public/wiki-page.view?name=ProtocolGuides'},
                 {name: 'View My Requirement Status', url: '<%=contextPath%>' + '/WNPRC/WNPRC_Units/Animal_Services/Compliance_Training/Public/EHR_ComplianceDB-My_Requirements.view'},
                 {name: 'View/Download PDFs of Signs, Posters and Guides', url: '<%=contextPath%>' + '/WNPRC/WNPRC_Units/Animal_Services/Compliance_Training/Public/query-executeQuery.view?schemaName=lists&query.queryName=Signs'},
                 {name: 'Download Paper Forms', url: '<%=contextPath%>' + '/WNPRC/WNPRC_Units/Animal_Services/Compliance_Training/Public/list-grid.view?listId=1399'},


### PR DESCRIPTION
#### Rationale
Users requested the link for protocol guidelines be removed

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
Deleted link on homepage for protocol guidelines