### PR TITLE
remove unused export

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/ColonyAlertsNotificationRevamp.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/ColonyAlertsNotificationRevamp.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.Set;
 import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.Results;
-import org.labkey.study.xml.Lab;
 
 import javax.script.ScriptEngine;
 


### PR DESCRIPTION
#### Rationale
Remove unused import, the XML bean class no longer exists

#### Related Pull Requests
https://github.com/LabKey/platform/pull/6101