### PR TITLE
No need to exclude Jakarta Activation API everywhere

### DIFF
--- a/ApiKey/build.gradle
+++ b/ApiKey/build.gradle
@@ -18,11 +18,7 @@ dependencies {
             "Eclipse Distribution License v1.0",
             "http://www.eclipse.org/org/documents/edl-v10.php",
             "Parsing XML"
-        ),
-        {
-            // Exclude in favor of angus activation from API
-            exclude group: "jakarta.activation", module: "jakarta.activation-api"
-        }
+        )
     )
 
     BuildUtils.addExternalDependency(

--- a/DBUtils/build.gradle
+++ b/DBUtils/build.gradle
@@ -19,11 +19,7 @@ dependencies {
             "Eclipse Distribution License v1.0",
             "http://www.eclipse.org/org/documents/edl-v10.php",
             "Parsing XML"
-        ),
-        {
-            // Exclude in favor of angus activation from API
-            exclude group: "jakarta.activation", module: "jakarta.activation-api"
-        }
+        )
     )
 
     BuildUtils.addExternalDependency(

--- a/DeviceProxy/build.gradle
+++ b/DeviceProxy/build.gradle
@@ -18,11 +18,7 @@ dependencies {
             "Eclipse Distribution License v1.0",
             "http://www.eclipse.org/org/documents/edl-v10.php",
             "Parsing XML"
-        ),
-        {
-            // Exclude in favor of angus activation from API
-            exclude group: "jakarta.activation", module: "jakarta.activation-api"
-        }
+        )
     )
 
     BuildUtils.addExternalDependency(


### PR DESCRIPTION
#### Rationale
Canonical version of Jakarta Activation API is now forced in `server/build.gradle`

#### Related Pull Requests
* https://github.com/LabKey/server/pull/937