### PR TITLE
Blood draw scheduling improvement

### DIFF
--- a/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
@@ -890,10 +890,11 @@ WNPRC_EHR.DatasetButtons = new function(){
                                 let txt = '';
                                 if (rsp) {
                                     for (let item of rsp) {
-                                        txt += '<div>' + item.message + item.projects + item.emails + '</div>' + '<br>';
+                                        txt += '<li>' + item.message + ' (Project(s): ' + item.projects + '; Contacts: <a href="mailto:' + item.emails + '">' + item.emails + '</a>'  + ')</li>';
                                     }
                                 }
                                 if (txt.length > 0){
+                                    txt = '<ul>' + txt + '</ul>'
                                     resp.innerHTML = '<span style="background:#acac16"> Warning:</span> ' + txt;
                                 } else {
                                     resp.innerHTML = '';

--- a/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
@@ -682,7 +682,6 @@ WNPRC_EHR.DatasetButtons = new function(){
                     jsonData: { records: records },
                     callback: function (config, success, xhr) {
                         if (success) {
-                            console.log(xhr);
                             resolve(xhr.responseText);
                         } else {
                             reject('Couldn\'t compare blood schedule, internal error.');

--- a/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
@@ -906,7 +906,7 @@ WNPRC_EHR.DatasetButtons = new function(){
                                 Ext4.getCmp('submitButton').enable()
                                 console.error(error);
                                 let resp = document.getElementById('bloodCompareResponse');
-                                resp.innerHTML = '<p>Error checking blood schedule, you are still able to submit. Please contact EHR admins with details: ' + JSON.parse(error) + '</p>'
+                                resp.innerHTML = '<p>Error checking blood schedule, you are still able to submit. Please contact EHR admins with details: ' + new Date() + ' ' + JSON.parse(error) + '</p>'
                             });
                         }
                     }

--- a/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
@@ -674,7 +674,7 @@ WNPRC_EHR.DatasetButtons = new function(){
                 }
         },
 
-        getMoreItems: function(records) {
+        checkBloodSchedule: function(records) {
 
             return new Promise((resolve, reject) => {
                 LABKEY.Ajax.request({
@@ -883,7 +883,7 @@ WNPRC_EHR.DatasetButtons = new function(){
                     }],
                     listeners: {
                         afterrender: () => {
-                            this.getMoreItems(records).then(response => {
+                            this.checkBloodSchedule(records).then(response => {
                                 let resp = document.getElementById('bloodCompareResponse');
                                 let rsp = JSON.parse(response).message;
                                 let txt = '';

--- a/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
@@ -907,6 +907,7 @@ WNPRC_EHR.DatasetButtons = new function(){
                                 console.error(error);
                                 let resp = document.getElementById('bloodCompareResponse');
                                 resp.innerHTML = '<p>Error checking blood schedule, you are still able to submit. Please contact EHR admins with details: ' + new Date() + ' ' + JSON.parse(error) + '</p>'
+                                Ext4.getCmp('change-request-form').setHeight('100%')
                             });
                         }
                     }

--- a/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
@@ -673,6 +673,26 @@ WNPRC_EHR.DatasetButtons = new function(){
                     }
                 }
         },
+
+        getMoreItems: function(records) {
+
+            return new Promise((resolve, reject) => {
+                LABKEY.Ajax.request({
+                    url: LABKEY.ActionURL.buildURL('WNPRC_EHR', 'CompareBloodSchedules'),
+                    jsonData: { records: records },
+                    callback: function (config, success, xhr) {
+                        if (success) {
+                            console.log(xhr);
+                            resolve(xhr.responseText);
+                        } else {
+                            reject('Couldn\'t compare blood schedule, internal error.');
+                        }
+                    }
+                })
+            });
+
+        },
+
         /**
          * This add a handler to a dataset that allows the user to change the QCState of the records, designed to approve or deny blood requests.
          * It also captures values for 'billedBy' and 'instructions'.
@@ -710,14 +730,26 @@ WNPRC_EHR.DatasetButtons = new function(){
                     title: 'Change Request Status',
                     width: 430,
                     autoHeight: true,
+                    id: 'change-request-window',
                     items: [{
                         xtype: 'form',
+                        height: '100%',
                         ref: 'theForm',
+                        id: 'change-request-form',
+                        autoHeight: true,
                         bodyStyle: 'padding: 5px;',
                         defaults: {
                             border: false
                         },
-                        items: [{
+                        items: [
+
+                            {
+                                id:'bloodCompareResponseWrapper',
+                                height: '100%',
+                                html: '<div id="bloodCompareResponse"><i class="fa fa-spinner fa-pulse"></i> loading..</div>',
+                                tag: 'div'
+                            },
+                            {
                             html: 'Total Records: '+checked.length+'<br><br>',
                             tag: 'div'
                         },{
@@ -767,10 +799,11 @@ WNPRC_EHR.DatasetButtons = new function(){
                     }],
                     buttons: [{
                         text:'Submit',
-                        disabled:false,
+                        disabled:true,
                         formBind: true,
                         ref: '../submit',
                         scope: this,
+                        id: 'submitButton',
                         handler: function(o){
                             var win = o.up('window');
                             var form = win.down('form');
@@ -848,7 +881,34 @@ WNPRC_EHR.DatasetButtons = new function(){
                         handler: function(o){
                             o.ownerCt.ownerCt.close();
                         }
-                    }]
+                    }],
+                    listeners: {
+                        afterrender: () => {
+                            this.getMoreItems(records).then(response => {
+                                let resp = document.getElementById('bloodCompareResponse');
+                                let rsp = JSON.parse(response).message;
+                                let txt = '';
+                                if (rsp) {
+                                    for (let item of rsp) {
+                                        txt += '<div>' + item.message + item.projects + item.emails + '</div>' + '<br>';
+                                    }
+                                }
+                                if (txt.length > 0){
+                                    resp.innerHTML = '<span style="background:#acac16"> Warning:</span> ' + txt;
+                                } else {
+                                    resp.innerHTML = '';
+                                }
+                                Ext4.getCmp('submitButton').enable()
+                                // Have to reset the height since the form has a set height after initial rendering,
+                                // but when text is dynamically added the height does not change.
+                                Ext4.getCmp('change-request-form').setHeight('100%')
+                            }).catch(error => {
+                                Ext4.getCmp('submitButton').enable()
+                                console.error(error);
+                                // Handle the error, e.g., display an error message in the window
+                            });
+                        }
+                    }
                 }).show();
             }
         },

--- a/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
@@ -906,7 +906,7 @@ WNPRC_EHR.DatasetButtons = new function(){
                                 Ext4.getCmp('submitButton').enable()
                                 console.error(error);
                                 let resp = document.getElementById('bloodCompareResponse');
-                                resp.innerHTML = '<p>Error checking blood schedule. Please contact EHR admins. Details: ' + JSON.parse(error) + '</p>'
+                                resp.innerHTML = '<p>Error checking blood schedule, you are still able to submit. Please contact EHR admins with details: ' + JSON.parse(error) + '</p>'
                             });
                         }
                     }

--- a/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/datasetButtons.js
@@ -905,7 +905,8 @@ WNPRC_EHR.DatasetButtons = new function(){
                             }).catch(error => {
                                 Ext4.getCmp('submitButton').enable()
                                 console.error(error);
-                                // Handle the error, e.g., display an error message in the window
+                                let resp = document.getElementById('bloodCompareResponse');
+                                resp.innerHTML = '<p>Error checking blood schedule. Please contact EHR admins. Details: ' + JSON.parse(error) + '</p>'
                             });
                         }
                     }

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
@@ -37,9 +37,11 @@ import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.SimpleRedirectAction;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.RuntimeSQLException;
@@ -76,11 +78,13 @@ import org.labkey.api.security.RequiresNoPermission;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.RequiresSiteAdmin;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.URLHelper;
@@ -123,12 +127,15 @@ import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -2105,4 +2112,143 @@ public class WNPRC_EHRController extends SpringActionController
             return response;
         }
     }
+
+    public static class CompareBloodSchedulesForm
+    {
+        private List<Map<String,Object>> _records;
+        public List<Map<String,Object>> getRecords()
+        {
+            return _records;
+        }
+
+        public void setRecords(List<Map<String,Object>> records)
+        {
+            _records = records;
+        }
+    }
+
+    public static String convertSetToString(Set<?> set, String delimiter) {
+        StringBuilder sb = new StringBuilder();
+        Iterator<?> iterator = set.iterator();
+
+        while (iterator.hasNext()) {
+            Object element = iterator.next();
+            sb.append(element);
+            if (iterator.hasNext()) {
+                sb.append(delimiter + " ");
+            }
+        }
+
+        return sb.toString();
+    }
+
+    @ActionNames("CompareBloodSchedules")
+    @RequiresNoPermission()
+    public class comparebloodSchedulesAction extends ReadOnlyApiAction<CompareBloodSchedulesForm>
+    {
+
+        @Override
+        public ApiResponse execute(CompareBloodSchedulesForm form, BindException errors) throws IOException, InvalidFormatException
+        {
+
+            ApiSimpleResponse response = new ApiSimpleResponse();
+
+            Map<String, List<Map<String, Object>>> groupedById = new HashMap<>();
+            for (Map<String,Object> mp : form.getRecords())
+            {
+                String id = (String) mp.get("Id");
+                groupedById.computeIfAbsent(id, k -> new ArrayList<>()).add(mp);
+            }
+
+            List<Map<String,Object>> messageList = new ArrayList<>();
+            //messages -> Map<String, String>
+
+            for (Map.Entry<String, List<Map<String, Object>>> entry : groupedById.entrySet())
+            {
+                Map<String, Object> theMessage = new HashMap<>();
+
+                Set<String> lsids = new HashSet<>();
+                List<Map<String, Object>> records = entry.getValue();
+
+                Set<java.time.LocalTime> uniqueTimes = new HashSet<>();
+                Set<String> uniqueRequestors = new HashSet<>();
+                Set<Integer> uniqueProjects = new HashSet<>();
+                Set<Integer>  uniqueCreatedBy = new HashSet<>();
+
+
+                // Create a Set to track unique dates
+                for (int i = 0; i < records.size() - 1; i++)
+                {
+                    Map<String, Object> record1 = records.get(i);
+                    String dateTimeString1 = (String) record1.get("date");
+
+                    lsids.add((String) record1.get("lsid"));
+
+                    for (int j = i + 1; j < records.size(); j++)
+                    {
+                        Map<String, Object> record2 = records.get(j);
+                        String dateTimeString2 = (String) record2.get("date");
+                        lsids.add((String) record1.get("lsid"));
+
+                        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+
+                        LocalDateTime dateTime1 = LocalDateTime.parse(dateTimeString1, formatter);
+
+                        LocalDateTime dateTime2 = LocalDateTime.parse(dateTimeString2, formatter);
+
+                        java.time.LocalDate date1 = dateTime1.toLocalDate();
+                        java.time.LocalTime time1 = dateTime1.toLocalTime();
+
+                        java.time.LocalDate date2 = dateTime2.toLocalDate();
+                        java.time.LocalTime time2 = dateTime2.toLocalTime();
+
+                        if (date1.isEqual(date2) && !time1.equals(time2))
+                        {
+                            uniqueTimes.add(time1);
+                            uniqueTimes.add(time2);
+                        }
+                    }
+                }
+                if (uniqueTimes.size() > 0)
+                {
+                    //get requestor and project information
+
+                    SimpleFilter myFilter = new SimpleFilter(FieldKey.fromString("lsid"), String.join("; ", lsids), CompareType.CONTAINS_ONE_OF);
+                    //Runs query with updated info.
+                    TableInfo ti = QueryService.get().getUserSchema(getUser(), getContainer(), "study").getTable("Blood Draws");
+                    TableSelector myTable = new TableSelector(ti, PageFlowUtil.set("lsid", "project", "Id", "requestor", "createdby"), myFilter, null);
+                    Map<String, Object>[] rows = myTable.getMapArray();
+                    for (Map<String, Object> row : rows)
+                    {
+                        uniqueRequestors.add((String) row.get("requestor"));
+                        uniqueProjects.add((Integer) row.get("project"));
+                        uniqueCreatedBy.add((Integer) row.get("createdBy"));
+                    }
+
+
+                    List<String> emails = new ArrayList<>();
+                    for (var userId : uniqueCreatedBy)
+                    {
+                        var user = UserManager.getUser(userId);
+
+                        if (user != null)
+                            emails.add(user.getEmail());
+                    }
+
+                    //pull out requestors email/userid
+                    theMessage.put("emails", String.join(",", emails));
+                    theMessage.put("projects", convertSetToString(uniqueProjects, ","));
+                    theMessage.put("message",entry.getKey() + " has "+ uniqueTimes.size() + " draws on the same day but at different times.");
+
+
+                    messageList.add(theMessage);
+                }
+            }
+            response.put("message", messageList);
+
+            return response;
+
+        }
+    }
+
 }

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
@@ -126,12 +126,12 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2152,22 +2152,84 @@ public class WNPRC_EHRController extends SpringActionController
         {
 
             ApiSimpleResponse response = new ApiSimpleResponse();
-
             Map<String, List<Map<String, Object>>> groupedById = new HashMap<>();
+            Map<Timestamp, List<Map<String, Object>>> groupedByDate = new HashMap<>();
+            List<String> lsids = new ArrayList<>();
+
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+            Date parsedDate;
+
             for (Map<String,Object> mp : form.getRecords())
             {
                 String id = (String) mp.get("Id");
-                groupedById.computeIfAbsent(id, k -> new ArrayList<>()).add(mp);
+                try
+                {
+                    //convert the date to Timestamp since this is what comes from the db later
+                    parsedDate = dateFormat.parse((String) mp.get("date"));
+                    Timestamp date = new Timestamp(parsedDate.getTime());
+                    mp.put("date", date);
+                    groupedById.computeIfAbsent(id, k -> new ArrayList<>()).add(mp);
+                    groupedByDate.computeIfAbsent(date, k -> new ArrayList<>()).add(mp);
+                }
+                catch (ParseException e)
+                {
+                    throw new RuntimeException(e);
+                }
             }
 
+
+            Set<String> ids = groupedById.keySet();
+            Set<Timestamp> dates = groupedByDate.keySet();
+
+            //get min date to query DB later
+            java.time.LocalDate minDate= java.time.LocalDate.now().plusYears(100);
+            for (Timestamp dateTime  : dates)
+            {
+                java.time.LocalDate date1 = dateTime.toLocalDateTime().toLocalDate();
+                minDate = date1.isBefore(minDate) ? date1 : minDate;
+            }
+
+            //get max date to query DB later
+            java.time.LocalDate maxDate = java.time.LocalDate.now().minusYears(100);
+            for (Timestamp dateTime : dates)
+            {
+                java.time.LocalDate date1 = dateTime.toLocalDateTime().toLocalDate();
+                maxDate = date1.isAfter(maxDate) ? date1 : maxDate;
+            }
+
+            //get any blood draws that have potentially the same date & id
+            Set<Integer> qcStates = new HashSet<>();
+            qcStates.add(EHRService.get().getQCStates(getContainer()).get(EHRService.QCSTATES.RequestApproved.getLabel()).getRowId());
+            qcStates.add(EHRService.get().getQCStates(getContainer()).get(EHRService.QCSTATES.Scheduled.getLabel()).getRowId());
+
+            SimpleFilter bloodFilter = new SimpleFilter(FieldKey.fromString("lsid"), String.join("; ",ids), CompareType.CONTAINS_ONE_OF);
+            bloodFilter.addCondition(FieldKey.fromString("date"), minDate, CompareType.DATE_GTE);
+            bloodFilter.addCondition(FieldKey.fromString("date"), maxDate, CompareType.DATE_LTE);
+            bloodFilter.addCondition(FieldKey.fromString("qcstate"), qcStates, CompareType.IN);
+            //Runs query with updated info.
+            TableInfo bloodTi = QueryService.get().getUserSchema(getUser(), getContainer(), "study").getTable("Blood Draws");
+            TableSelector bloodTable = new TableSelector(bloodTi, PageFlowUtil.set("lsid", "date", "project", "Id", "requestor", "createdby"), bloodFilter, null);
+            Map<String, Object>[] bloodRows = bloodTable.getMapArray();
+
+            //add the records from the db to our groupedById array
+            for (Map<String, Object> row : bloodRows)
+            {
+                for (Map.Entry<String, List<Map<String, Object>>> entry: groupedById.entrySet())
+                {
+                    if (entry.getKey().equals(row.get("Id")))
+                    {
+                        entry.getValue().add(row);
+                    }
+                }
+            }
+
+
             List<Map<String,Object>> messageList = new ArrayList<>();
-            //messages -> Map<String, String>
 
             for (Map.Entry<String, List<Map<String, Object>>> entry : groupedById.entrySet())
             {
                 Map<String, Object> theMessage = new HashMap<>();
 
-                Set<String> lsids = new HashSet<>();
                 List<Map<String, Object>> records = entry.getValue();
 
                 Set<java.time.LocalTime> uniqueTimes = new HashSet<>();
@@ -2180,27 +2242,22 @@ public class WNPRC_EHRController extends SpringActionController
                 for (int i = 0; i < records.size() - 1; i++)
                 {
                     Map<String, Object> record1 = records.get(i);
-                    String dateTimeString1 = (String) record1.get("date");
+                    Timestamp dateTime1 = (Timestamp) record1.get("date");
 
                     lsids.add((String) record1.get("lsid"));
 
                     for (int j = i + 1; j < records.size(); j++)
                     {
                         Map<String, Object> record2 = records.get(j);
-                        String dateTimeString2 = (String) record2.get("date");
+                        Timestamp dateTime2 = (Timestamp) record2.get("date");
                         lsids.add((String) record1.get("lsid"));
 
-                        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
-                        LocalDateTime dateTime1 = LocalDateTime.parse(dateTimeString1, formatter);
+                        java.time.LocalDate date1 = dateTime1.toLocalDateTime().toLocalDate();
+                        java.time.LocalTime time1 = dateTime1.toLocalDateTime().toLocalTime();
 
-                        LocalDateTime dateTime2 = LocalDateTime.parse(dateTimeString2, formatter);
-
-                        java.time.LocalDate date1 = dateTime1.toLocalDate();
-                        java.time.LocalTime time1 = dateTime1.toLocalTime();
-
-                        java.time.LocalDate date2 = dateTime2.toLocalDate();
-                        java.time.LocalTime time2 = dateTime2.toLocalTime();
+                        java.time.LocalDate date2 = dateTime2.toLocalDateTime().toLocalDate();
+                        java.time.LocalTime time2 = dateTime2.toLocalDateTime().toLocalTime();
 
                         if (date1.isEqual(date2) && !time1.equals(time2))
                         {
@@ -2225,7 +2282,6 @@ public class WNPRC_EHRController extends SpringActionController
                         uniqueCreatedBy.add((Integer) row.get("createdBy"));
                     }
 
-
                     List<String> emails = new ArrayList<>();
                     for (var userId : uniqueCreatedBy)
                     {
@@ -2239,7 +2295,6 @@ public class WNPRC_EHRController extends SpringActionController
                     theMessage.put("emails", String.join(",", emails));
                     theMessage.put("projects", convertSetToString(uniqueProjects, ","));
                     theMessage.put("message",entry.getKey() + " has "+ uniqueTimes.size() + " draws on the same day but at different times.");
-
 
                     messageList.add(theMessage);
                 }

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRController.java
@@ -41,7 +41,6 @@ import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.RuntimeSQLException;

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -3701,6 +3701,68 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         */
 
     }
+
+    @Test
+    public void testBloodDrawDoubleScheduleWarning() throws Exception
+    {
+        goToProjectHome();
+        ReusableTestFunctions myReusableFunctions = new ReusableTestFunctions();
+
+        Integer numTubes = 1;
+        String tubeType = "EDTA";
+        Integer project = 640991;
+        String account = "acct102";
+        Double tubeVolOK = 1.0;
+        Double quantityOK = tubeVolOK * numTubes;
+        InsertRowsCommand bloodCmd = new InsertRowsCommand("study", "blood");
+        Date dt = prepareDate(new Date(), 10, 0);
+        Integer requestPending = myReusableFunctions.getQCStateRowID("Request: Pending");
+
+
+        bloodCmd.addRow(new HashMap<String, Object>()
+        {
+            {
+                put("Id", TEST_SUBJECTS[0]);
+                put("date", dt);
+                put("project", project);
+                put("account", account);
+                put("tube_type", tubeType);
+                put("tube_vol", tubeVolOK);
+                put("num_tubes", numTubes);
+                put("quantity", quantityOK);
+                put("additionalServices", null);
+                put("restraint", "Chemical");
+                put("restraintDuration", "< 30 min");
+                put("instructions", "test special instruction");
+                put("remark", "test remark");
+                put("performedby", "autotest");
+                put("QCState", requestPending);
+
+            }
+        });
+        bloodCmd.execute(getApiHelper().getConnection(), getContainerPath());
+
+        SelectRowsCommand sr = new SelectRowsCommand("study","blood");
+        sr.addFilter("Id", TEST_SUBJECTS[0], Filter.Operator.EQUAL);
+        sr.addFilter("date", dt, Filter.Operator.EQUAL);
+        SelectRowsResponse resp2 = sr.execute(getApiHelper().getConnection(), EHR_FOLDER_PATH);
+        Assert.assertEquals(1, resp2.getRowCount());
+        Assert.assertEquals(requestPending, resp2.getRows().get(0).get("QCState"));
+
+
+        //approve some draws
+        goToEHRFolder();
+        waitAndClickAndWait(Locator.linkWithText("Enter Data"));
+        waitAndClick(Locator.linkWithText("Blood Draw Requests"));
+        //clickBootstrapTab("Blood Draw Requests");
+        waitForText(TEST_SUBJECTS[0]);
+        //need to find web part title name
+        DataRegionTable dr = DataRegionTable.findDataRegionWithinWebpart(this, "blood");
+
+
+        dr.checkCheckbox(0);
+
+    }
     protected String generateGUID()
     {
         return (String)executeScript("return LABKEY.Utils.generateUUID().toUpperCase()");

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -3702,6 +3702,11 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
 
     }
 
+    // Note: there is one flaw with this test below w.r.t the dates.
+    // the idea is to test two dates within the same day under a couple constraints,
+    // one is there can be no blood requests in the past, and another is it can only go up to 60 days into the future,
+    // so setting a date in the distant past or future is not possible, so we have to do a dynamic date using
+    // new Date() and offsetting the hours. If the first date happens to run within an hour before midnight, this test will fail.
     @Test
     public void testBloodDrawDoubleScheduleWarning() throws Exception
     {
@@ -3717,6 +3722,7 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         InsertRowsCommand bloodCmd = new InsertRowsCommand("study", "blood");
         Date dt = prepareDate(new Date(), 10, 0);
         Integer requestPending = myReusableFunctions.getQCStateRowID("Request: Pending");
+        Integer scheduled = myReusableFunctions.getQCStateRowID("Scheduled");
 
 
         bloodCmd.addRow(new HashMap<String, Object>()
@@ -3740,6 +3746,28 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
 
             }
         });
+        Date d2 = prepareDate(new Date(), 10, 1);
+        bloodCmd.addRow(new HashMap<String, Object>()
+        {
+            {
+                put("Id", TEST_SUBJECTS[0]);
+                put("date", d2);
+                put("project", project);
+                put("account", account);
+                put("tube_type", tubeType);
+                put("tube_vol", tubeVolOK);
+                put("num_tubes", numTubes);
+                put("quantity", quantityOK);
+                put("additionalServices", null);
+                put("restraint", "Chemical");
+                put("restraintDuration", "< 30 min");
+                put("instructions", "test special instruction");
+                put("remark", "test remark");
+                put("performedby", "autotest");
+                put("QCState", scheduled);
+
+            }
+        });
         bloodCmd.execute(getApiHelper().getConnection(), getContainerPath());
 
         SelectRowsCommand sr = new SelectRowsCommand("study","blood");
@@ -3756,12 +3784,21 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         waitAndClick(Locator.linkWithText("Blood Draw Requests"));
         //clickBootstrapTab("Blood Draw Requests");
         waitForText(TEST_SUBJECTS[0]);
-        //need to find web part title name
-        DataRegionTable dr = DataRegionTable.findDataRegionWithinWebpart(this, "blood");
 
+        WebElement parentDiv = getDriver().findElement(By.cssSelector("div[id*='lk-gen'][class='tab-pane active']"));
 
-        dr.checkCheckbox(0);
+        // Locate the form element within the parent div
+        WebElement formElement = parentDiv.findElement(By.xpath(".//form[contains(@id, 'lk-region-')]"));
 
+        // Get the value of the "lk-region-form" attribute
+        String formAttribute = formElement.getAttribute("lk-region-form");
+        DataRegionTable dataRegionTable = new DataRegionTable.DataRegionFinder(getDriver()).withName(formAttribute).find();
+
+        dataRegionTable.checkCheckbox(0);
+
+        dataRegionTable.clickHeaderMenu("More Actions", false, "Change Request Status");
+        waitForText(TEST_SUBJECTS[0] + " has 2 draws on the same day but at different times");
+        assertTextPresent(TEST_SUBJECTS[0] + " has 2 draws on the same day but at different times");
     }
     protected String generateGUID()
     {


### PR DESCRIPTION
#### Rationale
Sometimes (rarely) animals get scheduled for more than one blood draw in the same day at different times which means they get sedated twice. To avoid this, this PR builds in a mechanism to alert the users when approving blood draws if this is about to happen.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
