### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/ETLChemistryAnalyzer/resources/views/welcome.view.xml
+++ b/ETLChemistryAnalyzer/resources/views/welcome.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" title="ChemistryAnalyzer ETL Module">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
 </view>

--- a/WNPRC_EHR/resources/views/breeding_webpart.view.xml
+++ b/WNPRC_EHR/resources/views/breeding_webpart.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Pregnancies">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/breeding_webpart"/>
     </dependencies>

--- a/WNPRC_EHR/resources/views/ehrAdmin.view.xml
+++ b/WNPRC_EHR/resources/views/ehrAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="EHR Admin">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/WNPRC_EHR/resources/views/grid_panel_webpart.view.xml
+++ b/WNPRC_EHR/resources/views/grid_panel_webpart.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title=" ">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/grid_panel_webpart"/>
     </dependencies>

--- a/WNPRC_EHR/resources/views/research_ultrasounds_webpart.view.xml
+++ b/WNPRC_EHR/resources/views/research_ultrasounds_webpart.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Research Ultrasounds">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/research_ultrasounds_webpart"/>
     </dependencies>

--- a/WNPRC_Virology/resources/views/bannerInfo.view.xml
+++ b/WNPRC_Virology/resources/views/bannerInfo.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Info Panel">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
 </view>

--- a/WNPRC_Virology/resources/views/setAccounts.view.xml
+++ b/WNPRC_Virology/resources/views/setAccounts.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Update Accounts Panel">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/DropdownSelect"/>
         <!-- <dependency path="http://localhost:3001/DropdownSelect.js"/>-->

--- a/WNPRC_Virology/resources/views/viralLoadData.view.xml
+++ b/WNPRC_Virology/resources/views/viralLoadData.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Results Panel">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
 </view>

--- a/WNPRC_Virology/resources/views/welcome.view.xml
+++ b/WNPRC_Virology/resources/views/welcome.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" title="WNPRC Virology ETL Module">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
 </view>

--- a/WNPRC_r24/resources/views/welcome.view.xml
+++ b/WNPRC_r24/resources/views/welcome.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" title="R24 ETL Module">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
 </view>

--- a/WNPRC_u24/resources/views/welcome.view.xml
+++ b/WNPRC_u24/resources/views/welcome.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" title="U24 ETL Module">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
 </view>

--- a/primateid/resources/views/begin.view.xml
+++ b/primateid/resources/views/begin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" frame="portal" title="PrimateID Administration">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="https://cdn.jsdelivr.net/bluebird/3.5.0/bluebird.min.js"/>
         <dependency path="/internal/jQuery"/>


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.