### PR TITLE
Adding view for the historic assignments for protocols.

### DIFF
--- a/WNPRC_EHR/resources/queries/ehr/protocolTotalHistoricAnimalsBySpecies/.qview.xml
+++ b/WNPRC_EHR/resources/queries/ehr/protocolTotalHistoricAnimalsBySpecies/.qview.xml
@@ -1,0 +1,11 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView">
+   <columns>
+       <column name="protocol"/>
+       <column name="approve"/>
+       <column name="Species"/>
+       <column name="TotalAnimals"/>
+   </columns>
+   <sorts>
+       <sort column="protocol"/>
+   </sorts>
+</customView>


### PR DESCRIPTION
 For WNPRC internal ticket #19822.

#### Rationale
Users requested to remove a column from the protocol information page. Added a new view removing the column "# Animal Allowed"