### PR TITLE
24.11 fb change log folder

### DIFF
--- a/docker/development/compose.yaml
+++ b/docker/development/compose.yaml
@@ -8,7 +8,7 @@ services:
     image: wnprcehr/labkey${LK_PROD}:$LK_VERSION${LK_FB}    
     volumes:
       - "${LK_FILES_DIR}:/backups/new_files_dir"
-      - "${LK_LOG_DIR}:/usr/local/tomcat/logs"
+      - "${LK_LOG_DIR}:/labkey/logs"
       - "${LK_MODULE_DEPLOY_DIR}:/usr/local/modules"
       - "${LK_SESSION_DIR}:/usr/local/labkey/sessions"
     expose:

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -61,15 +61,6 @@ RUN chown -Rc labkey:labkey ${LABKEY_HOME}
 
 EXPOSE 8080
 
-#USER labkey
-#CMD ["/bin/bash", "-c", "ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && envsubst < /root/netrc.template > /root/.netrc && chmod 600 /root/.netrc && { \\cp -f /usr/local/modules/*.module /usr/local/labkey/modules/ &>/dev/null ; /etc/replacingSecrets.sh && systemctl daemon-reload && systemctl start labkey_server ; }"]
-#CMD ["/bin/bash", "-c", "ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && envsubst < /root/netrc.template > /root/.netrc && chmod 600 /root/.netrc && { \\cp -f /usr/local/modules/*.module /usr/local/labkey/modules/ &>/dev/null ;}", "java", "-jar", "labkeyServer.jar"]
-#CMD ["/bin/bash", "-c", "ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && envsubst < /root/netrc.template > /root/.netrc && chmod 600 /root/.netrc && { \\cp -f /usr/local/modules/*.module /usr/local/labkey/modules/ &>/dev/null ; java -jar /labkey/labkeyServer.jar;}"]
 ENTRYPOINT ["/etc/replacingSecrets.sh" ]
 
-#working 
-#CMD ["java", "-XX:MaxRAMPercentage=75.0", "-Dlabkey.home=$LABKEY_HOME" , "-Dlabkey.log.home=/labkey/logs", "-Dlogback.debug=true", "-jar", "/labkey/labkey/labkeyServer.jar"]
 CMD java -XX:+HeapDumpOnOutOfMemoryError -XX:MaxRAMPercentage=75.0 -Dlabkey.home=$LABKEY_HOME -Dlabkey.log.home=$LABKEY_LOGS -Dlogback.debug=true -jar /labkey/labkey/labkeyServer.jar
-#ENTRYPOINT ["/bin/bash", "-c", "ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && envsubst < /root/netrc.template > /root/.netrc && chmod 600 /root/.netrc && { \\cp -f /usr/local/modules/*.module /usr/local/labkey/modules/ &>/dev/null ; /etc/replacingSecrets.sh; }" ]
-
-#CMD ["sudo","-u","labkey","java","-XX:MaxRAMPercentage=75.0", "-Dlabkey.home=$LABKEY_HOME" , "-Dlabkey.log.home=/labkey/logs", "-Dlogback.debug=true", "-jar", "/labkey/labkeyServer.jar"]


### PR DESCRIPTION
#### Rationale
Fixing problem with location of logs files for the secondary instances of docker

#### Changes
* change the internal location for labkey logs files, to 'lake/logs'
* removing comments in the docker file for Labkey
