### PR TITLE
Remove unnecessary QueryWebPart renders

### DIFF
--- a/WNPRC_Purchasing/resources/views/purchasingReceiver.html
+++ b/WNPRC_Purchasing/resources/views/purchasingReceiver.html
@@ -6,5 +6,4 @@
         schemaName: 'ehr_purchasing',
         queryName: 'purchasingReceiverOverview'
     });
-    qwp.render();
 </script>

--- a/WNPRC_Purchasing/resources/views/purchasingRequester.html
+++ b/WNPRC_Purchasing/resources/views/purchasingRequester.html
@@ -15,5 +15,4 @@
                 {text: 'Create Request', url: LABKEY.ActionURL.buildURL('WNPRC_Purchasing', 'purchasingRequest', null, {isNewRequest: true, returnUrl:window.location})}
             ]}
     });
-    qwp.render();
 </script>

--- a/WNPRC_Virology/resources/views/viralLoadData.html
+++ b/WNPRC_Virology/resources/views/viralLoadData.html
@@ -10,7 +10,7 @@
                 schemaName: LABKEY.container.name + 'LinkedSchema',
                 queryName: 'viral_load_data_filtered',
                 frame: 'none'
-            }).render();
+            });
         });
 
     </script>


### PR DESCRIPTION
#### Rationale
If `renderTo` is defined in a QueryWebPart config, it is automatically rendered. Calling `render()` explicitly will request the data again and re-render the grid. This is inefficient at best but I suspect this re-render is behind some intermittent failures we've been seeing on TeamCity.
I'm cleaning up all that I could find.

#### Related Pull Requests
* N/A

#### Changes
* Remove unnecessary QueryWebPart renders