### PR TITLE
Remove unnecessary HttpView.currentView() casts in JSPs

### DIFF
--- a/WebUtils/src/org/labkey/webutils/view/JspPage.jsp
+++ b/WebUtils/src/org/labkey/webutils/view/JspPage.jsp
@@ -12,7 +12,7 @@
 <%@ page import="java.util.List" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    JspPage view = (JspPage) HttpView.currentView();
+    JspPage view = HttpView.currentView();
     JspPageModel model = (JspPageModel) getModelBean();
     Integer numberOfRenders = view.getNumberOfRenders();
     JSONArray unBindComponents = view.getUnbindComponents();


### PR DESCRIPTION
#### Rationale
Simple search and replace to clear warnings about unnecessary cast