### PR TITLE
Simplify and expand use of LinkBuilder factory methods

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/table/WNPRC_EHRCustomizer.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/table/WNPRC_EHRCustomizer.java
@@ -178,7 +178,7 @@ public class WNPRC_EHRCustomizer extends AbstractTableCustomizer
                         url.addParameter("formtype", formType);
                         url.addParameter("taskid", taskId);
 
-                        out.write(new LinkBuilder(HtmlString.of(rowId)).href(url).clearClasses());
+                        out.write(LinkBuilder.simpleLink(HtmlString.of(rowId), url));
                     } else {
                         super.renderGridCellContents(ctx, out);
                     }


### PR DESCRIPTION
#### Rationale
Using `LinkBuilder` factory methods simplifies the creation of links and provides consistency & clarity

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6561