### PR TITLE
Add emergency contact urls to wnprc units misc pages

### DIFF
--- a/WNPRC_EHR/resources/views/wnprcUnits.html
+++ b/WNPRC_EHR/resources/views/wnprcUnits.html
@@ -158,13 +158,14 @@ function createNavMenu()
         sections: [
             {header: 'Misc. Pages',
             items: [
-                {name: 'Change WNPRC Password', url: 'https://www.mynetid.wisc.edu/recover/pwdreset'},
                 {name: 'Employee List', url: '<%=contextPath%>' + '/WNPRC/EHR/query-executeQuery.view?schemaName=study&query.queryName=EmployeeList'},
                 {name: 'View My Requirement Status', url: '<%=contextPath%>' + '/WNPRC/WNPRC_Units/Animal_Services/Compliance_Training/Public/EHR_ComplianceDB-My_Requirements.view'},
                 {name: 'View/Download PDFs of Signs, Posters and Guides', url: '<%=contextPath%>' + '/WNPRC/WNPRC_Units/Animal_Services/Compliance_Training/Public/query-executeQuery.view?schemaName=lists&query.queryName=Signs'},
                 {name: 'Download Paper Forms', url: '<%=contextPath%>' + '/WNPRC/WNPRC_Units/Animal_Services/Compliance_Training/Public/list-grid.view?listId=1399'},
                 {name: 'PowerDMS', url: 'https://go.wisc.edu/mkg850'},
-                {name: 'Sample Manager', url: ' https://ehr.primate.wisc.edu/samplemanager/SampleManager/app.view#/home'}
+                {name: 'Sample Manager', url: ' https://ehr.primate.wisc.edu/samplemanager/SampleManager/app.view#/home'},
+                {name: 'Emergency Contacts', url: 'https://go.wisc.edu/62ke03'},
+                {name: 'Vet Emergency Contacts', url: 'https://go.wisc.edu/gdtw22'}
             ]}
         ]
     });


### PR DESCRIPTION
#### Rationale
[Request](https://ehr.primate.wisc.edu/issues/WNPRC/WNPRC_Units/Research_Services/EHR_Services/Issue_Tracker/details.view?issueId=20383) from Buddy and Dan to add two new contact links to the misc pages section under wnprc units.

#### Related Pull Requests


#### Changes
- Removed change WNPRC password as it was no longer needed
- Added emergency contact url
- Added vet emergency contact url