### PR TITLE
Migrate to renderGridCellContents(RenderContext, HtmlWriter)

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/table/WNPRC_EHRCustomizer.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/table/WNPRC_EHRCustomizer.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.wnprc_ehr.table;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.BaseColumnInfo;
@@ -51,7 +51,6 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.LinkBuilder;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.writer.HtmlWriter;
@@ -59,16 +58,9 @@ import org.labkey.dbutils.api.SimplerFilter;
 import org.labkey.wnprc_ehr.security.permissions.WNPRCAnimalRequestsEditPermission;
 import org.labkey.wnprc_ehr.security.permissions.WNPRCAnimalRequestsViewPermission;
 
-import java.io.IOException;
-import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * User: bimber
- * Date: 12/7/12
- * Time: 2:22 PM
- */
 public class WNPRC_EHRCustomizer extends AbstractTableCustomizer
 {
     protected static final Logger _log = LogManager.getLogger(WNPRC_EHRCustomizer.class);
@@ -976,27 +968,23 @@ public class WNPRC_EHRCustomizer extends AbstractTableCustomizer
                 sireid.setDisplayColumnFactory(colInfo -> new DataColumn(colInfo){
 
                     @Override
-                    public void renderGridCellContents(RenderContext ctx, Writer oldWriter, HtmlWriter out) throws IOException
+                    public void renderGridCellContents(RenderContext ctx, HtmlWriter out)
                     {
                         ActionURL url = new ActionURL("ehr", "participantView.view", us.getContainer());
                         String joinedIds = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "sireid"));
                         if (joinedIds != null)
                         {
                             String[] ids = joinedIds.split(",");
-                            String urlString = "";
                             for (int i = 0; i < ids.length; i++)
                             {
                                 String id = ids[i];
                                 url.replaceParameter("participantId", id);
-                                urlString += "<a href=\"" + PageFlowUtil.filter(url) + "\">";
-                                urlString += PageFlowUtil.filter(id);
-                                urlString += "</a>";
+                                out.write(LinkBuilder.simpleLink(id, url));
                                 if (i + 1 < ids.length)
                                 {
-                                    urlString += ", ";
+                                    out.write(", ");
                                 }
                             }
-                            oldWriter.write(urlString);
                         }
                     }
 
@@ -1020,7 +1008,7 @@ public class WNPRC_EHRCustomizer extends AbstractTableCustomizer
                 reason.setDisplayColumnFactory(colInfo -> new DataColumn(colInfo){
 
                     @Override
-                    public void renderGridCellContents(RenderContext ctx, Writer oldWriter, HtmlWriter out) throws IOException
+                    public void renderGridCellContents(RenderContext ctx, HtmlWriter out)
                     {
                         ActionURL url = new ActionURL("query", "recordDetails.view", us.getContainer());
                         String joinedReasons = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "reason"));
@@ -1031,7 +1019,6 @@ public class WNPRC_EHRCustomizer extends AbstractTableCustomizer
                             url.addParameter("query.queryName", "housing_reason");
                             url.addParameter("keyField", "value");
 
-                            StringBuilder urlString = new StringBuilder();
                             for (int i = 0; i < reasons.length; i++)
                             {
                                 String reasonForMoveValue = reasons[i];
@@ -1044,20 +1031,17 @@ public class WNPRC_EHRCustomizer extends AbstractTableCustomizer
                                 {
                                     reasonForMoveTitle = (String) ts.getMap().get("title");
                                     url.replaceParameter("key", reasonForMoveValue);
-                                    urlString.append("<a href=\"").append(PageFlowUtil.filter(url)).append("\">");
-                                    urlString.append(PageFlowUtil.filter(reasonForMoveTitle));
-                                    urlString.append("</a>");
+                                    out.write(LinkBuilder.simpleLink(reasonForMoveTitle, url));
                                 }
                                 else
                                 {
-                                    urlString.append(PageFlowUtil.filter("<" + reasonForMoveValue + ">"));
+                                    out.write("<" + reasonForMoveValue + ">");
                                 }
                                 if (i + 1 < reasons.length)
                                 {
-                                    urlString.append(", ");
+                                    out.write(", ");
                                 }
                             }
-                            oldWriter.write(urlString.toString());
                         }
                     }
 

--- a/WNPRC_Virology/src/org/labkey/wnprc_virology/table/WNPRC_VirologyCustomizer.java
+++ b/WNPRC_Virology/src/org/labkey/wnprc_virology/table/WNPRC_VirologyCustomizer.java
@@ -11,8 +11,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.ldk.table.AbstractTableCustomizer;
 import org.labkey.api.writer.HtmlWriter;
 
-import java.io.IOException;
-import java.io.Writer;
+import static org.labkey.api.util.DOM.STRONG;
 
 public class WNPRC_VirologyCustomizer extends AbstractTableCustomizer
 {
@@ -63,26 +62,21 @@ public class WNPRC_VirologyCustomizer extends AbstractTableCustomizer
         }
 
         @Override
-        public void renderGridCellContents(RenderContext ctx, Writer oldWriter, HtmlWriter out) throws IOException
+        public void renderGridCellContents(RenderContext ctx, HtmlWriter out)
         {
 
-            StringBuilder htmlString = new StringBuilder();
             String llodCol = ctx.get("below_llod").toString();
-            if (llodCol.toString().contains("Yes"))
+            if (llodCol.contains("Yes"))
             {
                 int parenIdx = llodCol.indexOf("(");
                 String firstPart = llodCol.substring(0, parenIdx);
                 String lastPart = llodCol.substring(parenIdx);
-                htmlString.append("<strong>");
-                htmlString.append(firstPart);
-                htmlString.append("</strong>");
-                htmlString.append(lastPart);
-                oldWriter.write(htmlString.toString());
+                STRONG(firstPart).appendTo(out);
+                out.write(lastPart);
             }
             else
             {
-                htmlString.append(llodCol);
-                oldWriter.write(htmlString.toString());
+                out.write(llodCol);
             }
         }
     }

--- a/docker/labkey/application.properties
+++ b/docker/labkey/application.properties
@@ -136,52 +136,6 @@ management.server.port=8081
 #jsonaccesslog.condition-if=attributeName
 #jsonaccesslog.condition-unless=attributeName
 
-## Define one or both of 'csp.report' and 'csp.enforce' to enable Content Security Policy (CSP) headers
-## Do not use these examples for any production environment without understanding the meaning of each directive!
-
-## example usage 1 - very strict, disallows 'external' websites, disallows unsafe-inline, but only reports violations (does not enforce)
-
-#csp.report=\
-#    default-src 'self';\
-#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
-#    object-src 'none' ;\
-#    style-src 'self' 'unsafe-inline' ;\
-#    img-src 'self' data: ;\
-#    font-src 'self' data: ;\
-#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\
-#    base-uri 'self' ;\
-#    upgrade-insecure-requests ;\
-#    frame-ancestors 'self' ;\
-#    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
-
-## example usage 2 - less strict but enforces directives, (NOTE: unsafe-inline is still required for many modules)
-
-#csp.enforce=\
-#    default-src 'self' https: ;\
-#    connect-src 'self' https: ${LABKEY.ALLOWED.CONNECTIONS};\
-#    object-src 'none' ;\
-#    style-src 'self' https: 'unsafe-inline' ;\
-#    img-src 'self' data: ;\
-#    font-src 'self' data: ;\
-#    script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\
-#    base-uri 'self' ;\
-#    upgrade-insecure-requests ;\
-#    frame-ancestors 'self' ;\
-#    report-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
-
-## Default CSP for TeamCity and dev deployments
-csp.report=\
-    default-src 'self' https: http: ;\
-    connect-src 'self' localhost:* ws: ${LABKEY.ALLOWED.CONNECTIONS} ;\
-    object-src 'none' ;\
-    style-src 'self' https: 'unsafe-inline' ;\
-    img-src 'self' https: data: ;\
-    font-src 'self' http: https: data: ;\
-    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
-    base-uri 'self' ;\
-    frame-ancestors 'self' ;\
-    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
-
 ## Use a custom logging configuration
 #logging.config=path/to/alternative/log4j2.xml
 


### PR DESCRIPTION
#### Rationale
Server-side HTML generation wants to use DOM, builders, and HtmlWriter

Also, get rid of CSP properties