### PR TITLE
Mark CageUI as only supporting Postgres; dependency on EHR

### DIFF
--- a/CageUI/build.gradle
+++ b/CageUI/build.gradle
@@ -24,4 +24,5 @@ plugins {
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/CageUI/module.properties
+++ b/CageUI/module.properties
@@ -23,3 +23,4 @@ URL: WNPRC/EHR/cageui-editLayout.view
 Name: CageUI
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: pgsql

--- a/CageUI/resources/schemas/cageui.xml
+++ b/CageUI/resources/schemas/cageui.xml
@@ -34,6 +34,7 @@
             <column columnName="created"/>
             <column columnName="modified"/>
             <column columnName="modifiedby"/>
+            <column columnName="extra_context"/>
         </columns>
     </table>
     <table tableName="racks" tableDbType="TABLE">


### PR DESCRIPTION
#### Rationale
The new CageUI module only has DB upgrade scripts for Postgres. However, it doesn't indicate that it lacks SQL Server support. This is causing test failures on TeamCity, as is the lack of an explicit dependency on EHR causing the upgrade scripts to run in a non-deterministic order.

#### Changes
* Mark the module as requiring `pgsql`. This can be undone if SQL Server upgrade scripts are added in the future.
* Declare dependency on EHR module to get schema upgrade scripts to run in the right order
* Add column to the XML listing to match actual `cageui.layout_history` table