### PR TITLE
Eliminate some warnings

### DIFF
--- a/CageUI/src/org/labkey/cageui/CageUIController.java
+++ b/CageUI/src/org/labkey/cageui/CageUIController.java
@@ -38,14 +38,15 @@ public class CageUIController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView("/org/labkey/cageui/view/hello.jsp");
+            return new JspView<>("/org/labkey/cageui/view/hello.jsp");
         }
 
+        @Override
         public void addNavTrail(NavTree root) { }
     }
-
 }

--- a/CageUI/src/org/labkey/cageui/query/LayoutHistoryTable.java
+++ b/CageUI/src/org/labkey/cageui/query/LayoutHistoryTable.java
@@ -41,11 +41,8 @@ import org.labkey.cageui.security.permissions.CageUIRoomCreatorPermission;
 import org.labkey.cageui.security.permissions.CageUITemplateCreatorPermission;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import static org.labkey.api.query.QueryUpdateService.ConfigParameters.PreferPKOverObjectUriAsKey;
 
 public class LayoutHistoryTable extends SimpleUserSchema.SimpleTable<CageUIUserSchema>
 {
@@ -69,7 +66,7 @@ public class LayoutHistoryTable extends SimpleUserSchema.SimpleTable<CageUIUserS
 
         // This checks permission before any data modification occurs
         @Override
-        public boolean hasPermission(@NotNull UserPrincipal user, Class<? extends Permission> perm)
+        public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
         {
             boolean hasPermission = super.hasPermission(user, perm);
             boolean isEditPerm = perm == InsertPermission.class || perm == UpdatePermission.class || perm == DeletePermission.class;

--- a/CageUI/src/org/labkey/cageui/query/RackTypesTable.java
+++ b/CageUI/src/org/labkey/cageui/query/RackTypesTable.java
@@ -39,7 +39,6 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.cageui.security.permissions.CageUITemplateCreatorPermission;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -65,7 +64,7 @@ public class RackTypesTable extends SimpleUserSchema.SimpleTable<CageUIUserSchem
 
         // This checks permission before any data modification occurs
         @Override
-        public boolean hasPermission(@NotNull UserPrincipal user, Class<? extends Permission> perm)
+        public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
         {
             boolean hasPermission = super.hasPermission(user, perm);
             boolean isEditPerm = perm == InsertPermission.class || perm == UpdatePermission.class || perm == DeletePermission.class;

--- a/CageUI/src/org/labkey/cageui/query/RacksTable.java
+++ b/CageUI/src/org/labkey/cageui/query/RacksTable.java
@@ -26,26 +26,19 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DuplicateKeyException;
 import org.labkey.api.query.InvalidKeyException;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
-import org.labkey.api.query.RuntimeValidationException;
 import org.labkey.api.query.SimpleQueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
-import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.view.UnauthorizedException;
-import org.labkey.cageui.security.permissions.CageUILayoutEditorAccessPermission;
-import org.labkey.cageui.security.permissions.CageUIRoomCreatorPermission;
 import org.labkey.cageui.security.permissions.CageUITemplateCreatorPermission;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +64,7 @@ public class RacksTable extends SimpleUserSchema.SimpleTable<CageUIUserSchema>
 
         // This checks permission before any data modification occurs
         @Override
-        public boolean hasPermission(@NotNull UserPrincipal user, Class<? extends Permission> perm)
+        public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
         {
             boolean hasPermission = super.hasPermission(user, perm);
             boolean isEditPerm = perm == InsertPermission.class || perm == UpdatePermission.class || perm == DeletePermission.class;

--- a/ETLChemistryAnalyzer/src/org/labkey/ETLChemistryAnalyzer/ETLChemistryAnalyzerController.java
+++ b/ETLChemistryAnalyzer/src/org/labkey/ETLChemistryAnalyzer/ETLChemistryAnalyzerController.java
@@ -36,11 +36,12 @@ public class ETLChemistryAnalyzerController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
-        public ModelAndView getView(Object o, BindException errors) throws Exception
+        @Override
+        public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView("/org/labkey/ETLChemistryAnalyzer/view/hello.jsp");
+            return new JspView<>("/org/labkey/ETLChemistryAnalyzer/view/hello.jsp");
         }
 
         @Override

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
@@ -105,7 +105,7 @@ public class WNPRC_PurchasingController extends SpringActionController
     @NotNull
     private List<User> getFolderAdmins()
     {
-        List<RoleAssignment> folderAdminGroups = getContainer().getPolicy().getAssignments().stream().filter(roleAssignment -> roleAssignment.getRole().getName().equals(FOLDER_ADMIN_ROLE)).collect(Collectors.toList());
+        List<RoleAssignment> folderAdminGroups = getContainer().getPolicy().getAssignments().stream().filter(roleAssignment -> roleAssignment.getRole().getName().equals(FOLDER_ADMIN_ROLE)).toList();
         List<User> folderAdmins = new ArrayList<>();
         for (RoleAssignment folderAdmin : folderAdminGroups)
         {
@@ -128,50 +128,57 @@ public class WNPRC_PurchasingController extends SpringActionController
     }
 
     @RequiresPermission(InsertPermission.class)
-    public class RequesterAction extends SimpleViewAction
+    public static class RequesterAction extends SimpleViewAction<Object>
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            WebPartFactory factory = Portal.getPortalPartCaseInsensitive("WNPRC Purchasing Requester");
+            WebPartFactory factory = Portal.getPortalPart("WNPRC Purchasing Requester");
             Portal.WebPart part = factory.createWebPart();
             getPageConfig().setTitle("Purchasing Requester");
             return Portal.getWebPartViewSafe(factory, getViewContext(), part);
         }
 
+        @Override
         public void addNavTrail(NavTree root) { }
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class PurchaseAdminAction extends SimpleViewAction
+    public static class PurchaseAdminAction extends SimpleViewAction<Object>
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            WebPartFactory factory = Portal.getPortalPartCaseInsensitive("WNPRC Purchasing Admin");
+            WebPartFactory factory = Portal.getPortalPart("WNPRC Purchasing Admin");
             getPageConfig().setTitle("Purchasing Admin");
             Portal.WebPart part = factory.createWebPart();
             return Portal.getWebPartViewSafe(factory, getViewContext(), part);
         }
 
+        @Override
         public void addNavTrail(NavTree root) { }
     }
 
     @RequiresPermission(UpdatePermission.class)
-    public class PurchaseReceiverAction extends SimpleViewAction
+    public static class PurchaseReceiverAction extends SimpleViewAction<Object>
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            WebPartFactory factory = Portal.getPortalPartCaseInsensitive("WNPRC Purchasing Receiver");
+            WebPartFactory factory = Portal.getPortalPart("WNPRC Purchasing Receiver");
             getPageConfig().setTitle("Purchasing Receiver");
             Portal.WebPart part = factory.createWebPart();
             return Portal.getWebPartViewSafe(factory, getViewContext(), part);
         }
 
+        @Override
         public void addNavTrail(NavTree root) { }
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class PurchasingRequestAction extends SimpleViewAction
+    public static class PurchasingRequestAction extends SimpleViewAction<Object>
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors)
         {
             ModuleHtmlView view = ModuleHtmlView.get(ModuleLoader.getInstance().getModule("WNPRC_Purchasing"), ModuleHtmlView.getGeneratedViewPath("RequestEntry"));
@@ -180,11 +187,12 @@ public class WNPRC_PurchasingController extends SpringActionController
             return view;
         }
 
+        @Override
         public void addNavTrail(NavTree root) { }
     }
 
     @RequiresPermission(InsertPermission.class)
-    public class GetFolderAdminsAction extends ReadOnlyApiAction
+    public class GetFolderAdminsAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors)
@@ -249,7 +257,7 @@ public class WNPRC_PurchasingController extends SpringActionController
 
             List<ValidationException> validationExceptions = WNPRC_PurchasingManager.get().submitRequestForm(getUser(), getContainer(), requestForm);
 
-            if (validationExceptions.size() > 0)
+            if (!validationExceptions.isEmpty())
             {
                 throw new BatchValidationException(validationExceptions, null);
             }
@@ -287,7 +295,7 @@ public class WNPRC_PurchasingController extends SpringActionController
             List<User> usersWithInsertPerm = SecurityManager.getUsersWithPermissions(getContainer(), Collections.singleton(InsertPermission.class));
 
             //get the lab end user who originated the request
-            List <User> labEndUsers = usersWithInsertPerm.stream().filter(u -> u.getUserId() == emailTemplateForm.getRequester().getUserId()).collect(Collectors.toList());
+            List <User> labEndUsers = usersWithInsertPerm.stream().filter(u -> u.getUserId() == emailTemplateForm.getRequester().getUserId()).toList();
             User endUser = labEndUsers.size() == 1 ? labEndUsers.get(0) : null;
 
             //request status change email notification
@@ -351,16 +359,16 @@ public class WNPRC_PurchasingController extends SpringActionController
             List<LineItem> removed = oldLineItems.stream().filter(o1 -> updatedLineItems.stream().noneMatch(o2 -> o2.getRowId() == o1.getRowId())).collect(Collectors.toList());
 
             List<LineItem> quantityChange = updatedLineItems.stream().filter(o1 -> oldLineItems.stream().noneMatch(o2 -> o1.getRowId() == o2.getRowId()
-                                                                                    && o2.getQuantity() == o1.getQuantity())).collect(Collectors.toList());
+                                                                                    && o2.getQuantity() == o1.getQuantity())).toList();
 
             boolean fullQuantityReceived = updatedLineItems.stream().filter(o2 -> o2.getQuantityReceived() >= o2.getQuantity()).count() == updatedLineItems.size();
 
-            if (removed.size() > 0 || quantityChange.size() > 0 || fullQuantityReceived)
+            if (!removed.isEmpty() || !quantityChange.isEmpty() || fullQuantityReceived)
             {
                 LineItemChangeEmailTemplate lineItemChangeEmailTemplate = EmailTemplateService.get().getEmailTemplate(LineItemChangeEmailTemplate.class);
                 lineItemChangeEmailTemplate.setUpdatedLineItemsList(updatedLineItems);
                 lineItemChangeEmailTemplate.setOldLineItemsList(oldLineItems);
-                lineItemChangeEmailTemplate.setDeletedLineItemFlag(removed.size() > 0);
+                lineItemChangeEmailTemplate.setDeletedLineItemFlag(!removed.isEmpty());
                 lineItemChangeEmailTemplate.setFullQuantityReceivedFlag(fullQuantityReceived);
                 lineItemChangeEmailTemplate.setNotificationBean(emailTemplateForm);
                 String emailSubject = lineItemChangeEmailTemplate.renderSubject(getContainer());
@@ -604,7 +612,7 @@ public class WNPRC_PurchasingController extends SpringActionController
         }
     }
 
-    public class EmailTemplateForm
+    public static class EmailTemplateForm
     {
         Integer _rowId;
         String _vendor;

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingFolderType.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingFolderType.java
@@ -27,7 +27,7 @@ public class WNPRC_PurchasingFolderType extends DefaultFolderType
 
     private static @Nullable Portal.WebPart createWebPart(String name)
     {
-        WebPartFactory factory = Portal.getPortalPartCaseInsensitive(name);
+        WebPartFactory factory = Portal.getPortalPart(name);
         return null != factory ? factory.createWebPart(WebPartFactory.LOCATION_BODY) : null;
     }
 

--- a/WNPRC_Virology/src/org/labkey/wnprc_virology/WNPRC_VirologyController.java
+++ b/WNPRC_Virology/src/org/labkey/wnprc_virology/WNPRC_VirologyController.java
@@ -2,8 +2,8 @@ package org.labkey.wnprc_virology;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.json.JSONObject;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.MutatingApiAction;
@@ -52,9 +52,10 @@ import static org.labkey.wnprc_virology.ViralLoadRSEHRRunner.virologyModule;
 public class WNPRC_VirologyController extends SpringActionController
 {
     public static final String CONFIGURE_VIROLOGY_FOLDER = "Configure WNPRC Virology Shared Data Folder";
-    private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(WNPRC_VirologyController.class);
     public static final String NAME = "wnprc_virology";
-    private static Logger _log = LogManager.getLogger(WNPRC_VirologyController.class);
+
+    private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(WNPRC_VirologyController.class);
+    private static final Logger _log = LogManager.getLogger(WNPRC_VirologyController.class);
 
     private static final String _sourceDataTableName = "viral_load_data_filtered";
 
@@ -64,11 +65,12 @@ public class WNPRC_VirologyController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
-        public ModelAndView getView(Object o, BindException errors) throws Exception
+        @Override
+        public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView("/org/labkey/wnprc_virology/view/hello.jsp");
+            return new JspView<>("/org/labkey/wnprc_virology/view/hello.jsp");
         }
 
         @Override
@@ -108,9 +110,9 @@ public class WNPRC_VirologyController extends SpringActionController
 
         List<Integer> newList = new ArrayList<>();
         List<JSONObject> currentList = new ArrayList<>();
-        for (int k = 0; k < accountNumbers.length; k ++)
+        for (int accountNumber : accountNumbers)
         {
-            newList.add(accountNumbers[k]);
+            newList.add(accountNumber);
         }
 
         SimpleQueryUpdater qu = new SimpleQueryUpdater(getUser(), viralLoadContainer, schemaName, queryName);
@@ -120,32 +122,31 @@ public class WNPRC_VirologyController extends SpringActionController
             currentList.add(ja.getJSONObject(r));
         }
 
-        if (newList.size() == 0)
+        if (newList.isEmpty())
         {
-            for (int j = 0; j < currentList.size(); j++)
+            for (JSONObject jo : currentList)
             {
-                JSONObject jo = currentList.get(j);
-                Map<String,Object> mp = new HashMap<>();
+                Map<String, Object> mp = new HashMap<>();
                 mp.put("folder_name", currentContainer.getName());
                 mp.put("account", jo.get("account"));
                 mp.put("rowid", jo.get("rowid"));
                 rowsToDelete.add(mp);
             }
-        } else if (ja.length() == 0)
+        }
+        else if (ja.isEmpty())
         {
-            for (int i = 0; i < newList.size(); i++)
+            for (Integer integer : newList)
             {
-                Map<String,Object> mp = new HashMap<>();
+                Map<String, Object> mp = new HashMap<>();
                 mp.put("folder_name", currentContainer.getName());
-                mp.put("account", newList.get(i));
+                mp.put("account", integer);
                 rowsToInsert.add(mp);
             }
-        } else if (newList.size() > 0 && ja.length() > 0)
+        }
+        else if (!ja.isEmpty())
         {
-
-            for (int t = 0; t < currentList.size(); t++)
+            for (JSONObject jo : currentList)
             {
-                JSONObject jo = currentList.get(t);
                 boolean neverFound = true;
                 for (int h = 0; h < newList.size(); h++)
                 {
@@ -157,27 +158,25 @@ public class WNPRC_VirologyController extends SpringActionController
                 }
                 if (neverFound)
                 {
-                    Map<String,Object> mp = new HashMap<>();
+                    Map<String, Object> mp = new HashMap<>();
                     mp.put("folder_name", currentContainer.getName());
                     mp.put("account", jo.get("account"));
                     mp.put("rowid", jo.get("rowid"));
                     rowsToDelete.add(mp);
                 }
             }
-            for (int g = 0; g < newList.size(); g++)
+            for (Integer integer : newList)
             {
-                Map<String,Object> mp = new HashMap<>();
+                Map<String, Object> mp = new HashMap<>();
                 mp.put("folder_name", currentContainer.getName());
-                mp.put("account", newList.get(g));
+                mp.put("account", integer);
                 rowsToInsert.add(mp);
             }
-
         }
         if (!rowsToInsert.isEmpty())
             qu.insert(rowsToInsert);
         if (!rowsToDelete.isEmpty())
             qu.delete(rowsToDelete);
-
     }
 
     /* An action to update accounts without folder setup */
@@ -276,15 +275,12 @@ public class WNPRC_VirologyController extends SpringActionController
             result.put("success", true);
             return new ApiSimpleResponse(result);
         }
-
-
     }
 
     // Intended to be called from test code
     @RequiresPermission(AdminPermission.class)
     public static class StartRSEHRJobAction extends MutatingApiAction<Object>
     {
-
         @Override
         public Object execute(Object o, BindException errors) throws Exception
         {
@@ -322,7 +318,6 @@ public class WNPRC_VirologyController extends SpringActionController
             QueryService.get().createLinkedSchema(getUser(), c, "wnprc_virology_linked", viralLoadContainer.getId(), "wnprc_virology", null, "grant_accounts, folders_accounts_mappings", null);
             return null;
         }
-
     }
 
     // Only to be called from test code

--- a/WNPRC_r24/src/org/labkey/wnprc_r24/wnprc_r24Controller.java
+++ b/WNPRC_r24/src/org/labkey/wnprc_r24/wnprc_r24Controller.java
@@ -36,11 +36,12 @@ public class wnprc_r24Controller extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
-        public ModelAndView getView(Object o, BindException errors) throws Exception
+        @Override
+        public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView("/org/labkey/wnprc_r24/view/hello.jsp");
+            return new JspView<>("/org/labkey/wnprc_r24/view/hello.jsp");
         }
 
         @Override

--- a/WNPRC_u24/src/org/labkey/wnprc_u24/wnprc_u24Controller.java
+++ b/WNPRC_u24/src/org/labkey/wnprc_u24/wnprc_u24Controller.java
@@ -36,11 +36,12 @@ public class wnprc_u24Controller extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
-        public ModelAndView getView(Object o, BindException errors) throws Exception
+        @Override
+        public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView("/org/labkey/wnprc_u24/view/hello.jsp");
+            return new JspView<>("/org/labkey/wnprc_u24/view/hello.jsp");
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
Just cleaning up some warnings flagged by IntelliJ, for example:
- Missing `@Override` and `@NotNull` annotations
- Bad generics
- Unused imports
- Use of deprecated `Portal.getPortalPartCaseInsensitive()` method
- etc.

No functional changes

IMO, no need for additional testing