### PR TITLE
Replace deprecated property assignment syntax

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -3,12 +3,12 @@ buildscript {
         mavenCentral()
         gradlePluginPortal()
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url = "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
             maven {
-                url "${artifactory_contextUrl}/plugins-snapshot-local"
+                url = "${artifactory_contextUrl}/plugins-snapshot-local"
             }
 
         }


### PR DESCRIPTION
#### Rationale
Gradle has deprecated the use of property assignment without the equals sign. Using it generates this warning
```
Script '/.../server/modules/wnprc-modules/gradle/java.gradle': line 7
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10. Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/9.0.0/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
```

#### Changes
* Use equal signs