### PR TITLE
Update query to reference auditlog.Client API Actions

### DIFF
--- a/WNPRC_EHR/resources/queries/core/SiteBackupLog.sql
+++ b/WNPRC_EHR/resources/queries/core/SiteBackupLog.sql
@@ -20,5 +20,4 @@ comment
 
 FROM auditlog."Client API Actions" a
 
-WHERE
-a.key1 = 'LabKey Server Backup'
+WHERE a.SubType = 'LabKey Server Backup'

--- a/WNPRC_EHR/resources/queries/core/SiteBackupLog.sql
+++ b/WNPRC_EHR/resources/queries/core/SiteBackupLog.sql
@@ -18,9 +18,7 @@ EventType,
 date,
 comment
 
-FROM auditlog.audit a
+FROM auditlog."Client API Actions" a
 
 WHERE
-a.key1 = 'LabKey Server Backup' AND
-a.EventType = 'Client API Actions'
-
+a.key1 = 'LabKey Server Backup'

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/AdminAlertsNotificationRevamp.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/AdminAlertsNotificationRevamp.java
@@ -5,10 +5,8 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.module.Module;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -142,14 +140,13 @@ public class AdminAlertsNotificationRevamp extends AbstractEHRNotification {
             // Creates filter.
             Date dateYesterday = dateToolkit.getDateXDaysFromNow(-1);
             SimpleFilter myFilter = new SimpleFilter("date", dateYesterday, CompareType.DATE_GTE);
-            myFilter.addCondition("key1", "LabKey Server Backup", CompareType.NEQ_OR_NULL);
-            myFilter.addCondition("EventType", "Client API Actions", CompareType.EQUAL);
+            myFilter.addCondition("SubType", "LabKey Server Backup", CompareType.NEQ_OR_NULL);
 
             // Runs query.
-            ArrayList<String> returnArray = notificationToolkit.getTableMultiRowSingleColumn(currentContainer, currentUser, "auditlog", "audit", myFilter, null, "RowId", null);
+            ArrayList<String> returnArray = notificationToolkit.getTableMultiRowSingleColumn(currentContainer, currentUser, "auditlog", "Client API Actions", myFilter, null, "RowId", null);
             this.numClientErrorsSinceYesterday = Long.valueOf(returnArray.size());
             // Creates a URL to view number of client errors since yesterday.
-            this.numClientErrorsSinceYesterdayURLView = notificationToolkit.createQueryURL(currentContainer, "execute", "auditlog", "audit", myFilter);
+            this.numClientErrorsSinceYesterdayURLView = notificationToolkit.createQueryURL(currentContainer, "execute", "auditlog", "Client API Actions", myFilter);
         }
     }
 }

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/SiteErrorAlertsRevamp.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/SiteErrorAlertsRevamp.java
@@ -56,10 +56,6 @@ public class SiteErrorAlertsRevamp extends AbstractEHRNotification {
         return "Revamped Notifications";
     }
 
-
-
-
-
     //Message Creation
     @Override
     public String getMessageBodyHTML(Container c, User u) {
@@ -69,13 +65,13 @@ public class SiteErrorAlertsRevamp extends AbstractEHRNotification {
 
         // Creates filter.
         SimpleFilter myFilter = new SimpleFilter("date", lastRunDate, CompareType.GTE);
-        myFilter.addCondition("key1", "LabKeyServer Backup", CompareType.NEQ);
+        myFilter.addCondition("SubType", "LabKeyServer Backup", CompareType.NEQ);
         // Gets columns to retrieve.
         String[] targetColumns = new String[]{"id"};
         // Runs query.
-        ArrayList<HashMap<String, String>> returnArray = notificationToolkit.getTableMultiRowMultiColumnWithFieldKeys(c, u, "auditlog", "audit", myFilter, null, targetColumns);
+        ArrayList<HashMap<String, String>> returnArray = notificationToolkit.getTableMultiRowMultiColumnWithFieldKeys(c, u, "auditlog", "Client API Actions", myFilter, null, targetColumns);
         // Creates URL.
-        String queryURL = notificationToolkit.createQueryURL(c, "execute", "auditlog", "audit", myFilter);
+        String queryURL = notificationToolkit.createQueryURL(c, "execute", "auditlog", "Client API Actions", myFilter);
 
         // Sends the message only if there are results (otherwise sends notification to admins via emptyNotificationRevamp).
         if (returnArray.isEmpty()) {
@@ -89,7 +85,6 @@ public class SiteErrorAlertsRevamp extends AbstractEHRNotification {
             return messageBody.toString();
         }
     }
-    
 }
 
 

--- a/docker/ehrcron/scripts/pg_backup/lkServerBackup.pl
+++ b/docker/ehrcron/scripts/pg_backup/lkServerBackup.pl
@@ -508,7 +508,7 @@ sub lk_log {
         -queryName     => "Client API Actions",
         -rows          =>
         [ {
-            "Key1"      => "LabKey Server Backup",
+            "SubType"   => "LabKey Server Backup",
             "Comment"   => $status,
             "Date"      => $date
         } ]


### PR DESCRIPTION
#### Rationale
EHR tests have been failing after the deprecation of the legacy "audit union" table because usage queries still use it. Switching this to query the provisioned table directly is more straightforward and likely more efficient.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6892