### PR TITLE
Support BIGINT Primary Keys

### DIFF
--- a/DBUtils/api-src/org/labkey/dbutils/api/SimpleQuery.java
+++ b/DBUtils/api-src/org/labkey/dbutils/api/SimpleQuery.java
@@ -1,5 +1,6 @@
 package org.labkey.dbutils.api;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.labkey.api.data.ColumnInfo;
@@ -267,15 +268,16 @@ public class SimpleQuery<RowType> extends QueryHelper {
             extGridColumn.put("tooltip", dc.getDescription());
         if (dc.getWidth() != null)
         {
+            extGridColumn.put("width", dc.getWidth());
             try
             {
                 //try to parse as integer (which is what Ext wants)
-                extGridColumn.put("width", Integer.parseInt(dc.getWidth()));
+                if (StringUtils.isNotBlank(dc.getWidth()))
+                    extGridColumn.put("width", Integer.parseInt(dc.getWidth()));
             }
-            catch(NumberFormatException e)
+            catch (NumberFormatException e)
             {
-                //include it as a string
-                extGridColumn.put("width", dc.getWidth());
+                // pass
             }
         }
 

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/WaterMonitoringNotification.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/WaterMonitoringNotification.java
@@ -17,6 +17,7 @@ package org.labkey.wnprc_ehr.notification;
 
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -149,7 +150,7 @@ public class WaterMonitoringNotification extends AbstractEHRNotification
         {
             //Organizing report by project
             Map<String,Object>[] totalWaterForDay = ts.getMapArray();
-            Map<Integer, List<Map<String,Object>>> projectMap = new HashMap<>();
+            Map<Integer, List<Map<String,Object>>> projectMap = new IntHashMap<>();
             int animalsWaterMeaning = 0;
             for(Map<String,Object> mapItem : totalWaterForDay){
                 int projectNum = ConvertHelper.convert(mapItem.get("project"),Integer.class);

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingController.java
@@ -38,6 +38,7 @@ import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.notification.NotificationService;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.Filter;
@@ -398,7 +399,7 @@ public class WNPRC_PurchasingController extends SpringActionController
 
         private Map<Integer, String> getPurchasingDirectorUserIds()
         {
-            Map<Integer, String> purchasingDirUserIds = new HashMap<>();
+            Map<Integer, String> purchasingDirUserIds = new IntHashMap<>();
             for (RoleAssignment roleAssignment : getContainer().getPolicy().getAssignments())
             {
                 if (roleAssignment.getRole().getName().equals(WNPRC_PurchasingDirectorRole.PURCHASING_DIRECTOR_ROLE_NAME))

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
@@ -44,6 +44,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 public class WNPRC_PurchasingManager
 {
     private static final WNPRC_PurchasingManager _instance = new WNPRC_PurchasingManager();
@@ -240,7 +242,7 @@ public class WNPRC_PurchasingManager
                     insertedPurchasingReq = qus.updateRows(user, container, purchasingRequestsData, null, errors, null, null);
 
                 if (null != insertedPurchasingReq)
-                    requestForm.setRowId((Integer) insertedPurchasingReq.get(0).get("rowId"));
+                    requestForm.setRowId(asInteger(insertedPurchasingReq.get(0).get("rowId")));
                 else
                 {
                     requestOrderErrors.addError(new SimpleValidationError("Unable to submit purchasing request"));

--- a/WNPRC_Virology/src/org/labkey/wnprc_virology/notification/ViralLoadQueueNotification.java
+++ b/WNPRC_Virology/src/org/labkey/wnprc_virology/notification/ViralLoadQueueNotification.java
@@ -4,6 +4,7 @@ import jakarta.mail.Address;
 import jakarta.mail.Message;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.Results;
@@ -65,7 +66,7 @@ public class ViralLoadQueueNotification extends AbstractEHRNotification
 
 
     public Map<String, Object> _emailSummaryTable;
-    public Map<Integer, String> _accounts = new HashMap<>();
+    public Map<Integer, String> _accounts = new IntHashMap<>();
     private static final Logger _log = LogHelper.getLogger(ViralLoadQueueNotification.class, "Server-side logger for WNPRC_Virology notifications");
 
     public ViralLoadQueueNotification(Module owner)
@@ -210,7 +211,7 @@ public class ViralLoadQueueNotification extends AbstractEHRNotification
                 }
                 // old notes:
                 //emails.put(createdByUserId, getEmailArray(notifyEmails)); - old way, user id is unique.
-                //used to use public Map<Integer, List<String>> emails = new HashMap<Integer,List<String>>();
+                //used to use public Map<Integer, List<String>> emails = new IntHashMap<Integer,List<String>>();
                 //but ideally instead of Integer as the key it would be a a string of:
                 //submitter email + notify email string(normalized = sorted in such a way there arent repeats).
                 countEmailsAndPut(notifyEmails);
@@ -247,7 +248,7 @@ public class ViralLoadQueueNotification extends AbstractEHRNotification
         }*/
         //pull out accounts
         Set<Integer> accounts = new HashSet<>();
-        Map<Integer, Integer> accountsAndCount = new HashMap<>();
+        Map<Integer, Integer> accountsAndCount = new IntHashMap<>();
         Integer arr[] = new Integer[VLSampleListResults.size()];
         for (int i = 0; i < VLSampleListResults.size(); i++)
         {

--- a/WNPRC_r24/resources/transform/src/MicrobiomeTransform.java
+++ b/WNPRC_r24/resources/transform/src/MicrobiomeTransform.java
@@ -31,7 +31,7 @@ public class MicrobiomeTransform extends AbstractAssayValidator
 {
     private File _errorFile;
     private Map<String, String> _runProperties = new HashMap<>();
-    private Map<Integer, String> _colMap = new HashMap<>();
+    private Map<Integer, String> _colMap = new IntHashMap<>();
     private Map<String, String> _dictionary = new HashMap<>();
     private final int numHeaderCols = 4;
 


### PR DESCRIPTION
#### Rationale
Implement support for tables with BIGINT primary keys.  E.g. RowId/ObjectId BIGSERIAL
Because of the large number of shared classes, utilities, services, etc, a lot of code was migrated to used Long.  Code should now assume that an generic integer object key (as opposed to a known table PK), could be a Long.

This PR is aimed at a) Supporting ObjectID BIGSERIAL b) making it possible (but not automatic) to migrate tables that want to use RowId BIGSERIAL.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New safer collection classes
  class Int/LongHashMap
  class Int/LongHashSet
explicit Class for key values in Map Objects returned by BaseSelector
  Selector.getValueMap(Class key)
safe "cast" using asInteger or asLong, as opposed to (Integer) and (Long)

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->
