### PR TITLE
Switch layout to portrait style dimensions

### DIFF
--- a/CageUI/resources/web/CageUI/static/RoomBorder.svg
+++ b/CageUI/resources/web/CageUI/static/RoomBorder.svg
@@ -17,9 +17,9 @@
   -  */
   -->
 
-<svg id="border_template" xmlns="http://www.w3.org/2000/svg" width="1290" height="810" viewBox="0 0 1290 810">
-    <rect id="resize-handle" x="1275.25" y="795.49" width="15" height="15.01"
+<svg id="border_template" xmlns="http://www.w3.org/2000/svg" width="810" height="1290" viewBox="0 0 810 1290">
+    <rect id="resize-handle" x="795.49" y="1275.25" width="15" height="15.01"
           style="fill:none; stroke:#231f20; stroke-miterlimit:10;" class="resize-handle"/>
-    <rect id="border-rect" x=".5" y=".5" width="1289" height="809"
+    <rect id="border-rect" x=".5" y=".5" width="809" height="1289"
           style="fill:none; stroke:#231f20; stroke-miterlimit:10;"/>
 </svg>

--- a/CageUI/src/client/components/layoutEditor/Editor.tsx
+++ b/CageUI/src/client/components/layoutEditor/Editor.tsx
@@ -295,8 +295,9 @@ const Editor: FC<EditorProps> = ({roomSize}) => {
         const updateItemType: RoomItemType = stringToRoomItem(parseWrapperId(draggedNodeId));
 
         if (targetRect) {
-            const cellX = Math.max(0,targetRect.x);
-            const cellY = Math.max(0,targetRect.y);
+            // update the found x and y coords with new cell coords if the object was outside the available layout range.
+            const cellX = targetRect.x < SVG_WIDTH && targetRect.x > 0 ? targetRect.x : 0;
+            const cellY = targetRect.y < SVG_HEIGHT && targetRect.y > 0 ? targetRect.y : 0;
 
             let newId: string;
 

--- a/CageUI/src/client/utils/constants.ts
+++ b/CageUI/src/client/utils/constants.ts
@@ -19,8 +19,8 @@
 import { Modification, ModLocations, ModRecord, ModTypes } from '../types/typings';
 
 export const CELL_SIZE = 30; // number of pixels of a cell for length/width
-export const SVG_WIDTH = 1290; // width of the layout svg
-export const SVG_HEIGHT = 810; // height of the layout svg
+export const SVG_WIDTH = 810; // width of the layout svg
+export const SVG_HEIGHT = 1290; // height of the layout svg
 
 //TODO finish styles
 export const Modifications: ModRecord = {


### PR DESCRIPTION
#### Rationale
- Users requested the layout editor to be portrait style instead of landscape

#### Related Pull Requests

#### Changes
- Switched height and width of the layout
- Bug fix for placing outside of grid with new portrait dimensions