### PR TITLE
Constants for many commonly used role names in tests

### DIFF
--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -108,6 +108,8 @@ import static org.junit.Assert.assertTrue;
 import static org.labkey.test.WebTestHelper.buildURL;
 import static org.labkey.test.WebTestHelper.getRemoteApiConnection;
 import static org.labkey.test.util.Ext4Helper.TextMatchTechnique.CONTAINS;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 /**
  * This should contain tests designed to validate EHR data entry or associated business logic.
@@ -3467,8 +3469,8 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
 
         //Navigates to various containers and sets corresponding permissions.
         beginAt(buildURL("project", getProjectName(), "begin"));
-        _permissionsHelper.setPermissions(BASIC_SUBMITTER.getGroup(), "Reader");
-        _permissionsHelper.setPermissions(BASIC_SUBMITTER.getGroup(), "Editor");
+        _permissionsHelper.setPermissions(BASIC_SUBMITTER.getGroup(), READER_ROLE);
+        _permissionsHelper.setPermissions(BASIC_SUBMITTER.getGroup(), EDITOR_ROLE);
         beginAt(buildURL("wnprc_billing", getContainerPath(), "updateProgramIncomeAccount"));
         _permissionsHelper.setPermissions(BASIC_SUBMITTER.getGroup(), "EHR Finance Admin");
 

--- a/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
@@ -62,6 +62,10 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.labkey.test.WebTestHelper.buildRelativeUrl;
 import static org.labkey.test.WebTestHelper.getRemoteApiConnection;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SUBMITTER_ROLE;
 
 @Category({EHR.class, WNPRC_EHR.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
@@ -216,10 +220,10 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         _permissionsHelper.addUserToProjGroup(REQUESTER_USER_1, getProjectName(), PURCHASE_REQUESTER_GROUP);
         _permissionsHelper.addUserToProjGroup(REQUESTER_USER_2, getProjectName(), PURCHASE_REQUESTER_GROUP);
 
-        _permissionsHelper.setPermissions(PURCHASE_ADMIN_GROUP, "Project Administrator");
-        _permissionsHelper.setPermissions(PURCHASE_REQUESTER_GROUP, "Submitter");
-        _permissionsHelper.setPermissions(PURCHASE_REQUESTER_GROUP, "Reader");
-        _permissionsHelper.setPermissions(PURCHASE_RECEIVER_GROUP, "Editor");
+        _permissionsHelper.setPermissions(PURCHASE_ADMIN_GROUP, PROJECT_ADMIN_ROLE);
+        _permissionsHelper.setPermissions(PURCHASE_REQUESTER_GROUP, SUBMITTER_ROLE);
+        _permissionsHelper.setPermissions(PURCHASE_REQUESTER_GROUP, READER_ROLE);
+        _permissionsHelper.setPermissions(PURCHASE_RECEIVER_GROUP, EDITOR_ROLE);
         _permissionsHelper.setUserPermissions(PURCHASE_DIRECTOR_USER, "WNPRC Purchasing Director");
     }
 

--- a/WNPRC_Virology/test/src/org/labkey/test/tests/wnprc_virology/WNPRC_VirologyTest.java
+++ b/WNPRC_Virology/test/src/org/labkey/test/tests/wnprc_virology/WNPRC_VirologyTest.java
@@ -26,6 +26,7 @@ import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PasswordUtil;
+import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.RemoteConnectionHelper;
 import org.labkey.test.util.SchemaHelper;
@@ -45,6 +46,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.labkey.test.WebTestHelper.buildRelativeUrl;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({WNPRC_EHR.class})
 public class WNPRC_VirologyTest extends ViralLoadAssayTest
@@ -172,7 +175,7 @@ public class WNPRC_VirologyTest extends ViralLoadAssayTest
         _containerHelper.createProject(PROJECT_NAME_EHR, type);
         _containerHelper.enableModules(Arrays.asList(MODULE_NAME, "Dumbster", "EHR_Billing", "DataIntegration"));
         _userHelper.createUser(ADMIN_USER);
-        _apiPermissionsHelper.setUserPermissions(ADMIN_USER, "Folder Administrator");
+        _apiPermissionsHelper.setUserPermissions(ADMIN_USER, FOLDER_ADMIN_ROLE);
         // Set up the module properties
         List<ModulePropertyValue> properties = new ArrayList<>();
         properties.add(new ModulePropertyValue(MODULE_NAME, "/", "virologyEHRVLSampleQueueFolderPath", PROJECT_NAME_EHR));
@@ -253,8 +256,8 @@ public class WNPRC_VirologyTest extends ViralLoadAssayTest
         _userHelper.createUser(TEST_USER);
         _userHelper.createUser(TEST_USER_2);
         _containerHelper.createSubfolder(getProjectNameRSEHR(), getProjectNameRSEHRPublic(), "Collaboration");
-        _apiPermissionsHelper.setUserPermissions(TEST_USER, "Reader");
-        _apiPermissionsHelper.setUserPermissions(TEST_USER_2, "Reader");
+        _apiPermissionsHelper.setUserPermissions(TEST_USER, READER_ROLE);
+        _apiPermissionsHelper.setUserPermissions(TEST_USER_2, READER_ROLE);
         createWiki("Information", "Information");
 
 


### PR DESCRIPTION
#### Rationale
There's an exciting new computer science concept - using constants instead of many copies of hard-code values. Let's give it a try with our most commonly used role names in automated tests.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2703

#### Changes
- Common role names available in PermissionsHelper
- Update tests to use them