### PR TITLE
Return Set<Class<?>> from Module "get test" methods

### DIFF
--- a/SelfRegistration/src/org/labkey/selfregistration/SelfRegistrationModule.java
+++ b/SelfRegistration/src/org/labkey/selfregistration/SelfRegistrationModule.java
@@ -53,7 +53,7 @@ public class SelfRegistrationModule extends CodeOnlyModule
     }
 
     @Override
-    public @NotNull Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return PageFlowUtil.set(SelfRegistrationController.TestCase.class);
     }

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -202,6 +202,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
         registerPermissions();
     }
 
+        @Override
         @NotNull
         protected Collection<WebPartFactory> createWebPartFactories()
         {
@@ -546,8 +547,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return new Reflections("org.labkey.wnprc_ehr").getSubTypesOf(Assert.class).stream()
                 .filter(c -> c.getSimpleName().endsWith("IntegrationTest"))
@@ -555,8 +555,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return new Reflections("org.labkey.wnprc_ehr").getSubTypesOf(Assert.class).stream()
                 .filter(c -> c.getSimpleName().endsWith("UnitTest"))

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/husbandry/WaterCalendarWebPartFactory.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/pages/husbandry/WaterCalendarWebPartFactory.java
@@ -16,8 +16,8 @@ public class WaterCalendarWebPartFactory extends BaseWebPartFactory
     public WaterCalendarWebPartFactory(){super ("Water Calendar");}
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webpart){
-
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webpart)
+    {
         Map<String, String> props = webpart.getPropertyMap();
 
         String animalIds = webpart.getPropertyMap().get("animalIds");
@@ -32,7 +32,7 @@ public class WaterCalendarWebPartFactory extends BaseWebPartFactory
             unBindJSON.put(unBindComponent);
         }
 
-        JspView view = new JspView("/org/labkey/wnprc_ehr/pages/husbandry/WaterCalendar.jsp");
+        JspView<?> view = new JspView<>("/org/labkey/wnprc_ehr/pages/husbandry/WaterCalendar.jsp");
         view.setTitle("Water Calendar");
         view.setFrame(WebPartView.FrameType.PORTAL);
 


### PR DESCRIPTION
#### Rationale
Eliminate IntelliJ warnings caused by `Module` methods `getUnitTests()` and `getIntegrationTests()` returning raw `Set<Class>`; they now return `Set<Class<?>>`.

Also, eliminate use of the deprecated `AbstractAuditTypeProvider()` constructor and overrides of `getDomainKind()` in its subclasses; we now always call the constructor that passes in a `DomainKind`.