### PR TITLE
Date reformatting for animal abstract

### DIFF
--- a/WNPRC_EHR/src/client/abstract/base/AnimalInfoPane.tsx
+++ b/WNPRC_EHR/src/client/abstract/base/AnimalInfoPane.tsx
@@ -41,6 +41,7 @@ let constructArrayForTable = (animalInfo) => {
     if (!animalInfo["metaData"]["fields"][i].hidden) {
       let fieldMetadata = animalInfo["metaData"]["fields"][i];
       let key = getNameOfField(fieldMetadata);
+      let isDate: boolean = fieldMetadata.type === "date";
 
       let column = animalInfo["rows"][0][key];
       //cover the case where column could be an array
@@ -50,7 +51,7 @@ let constructArrayForTable = (animalInfo) => {
 
       let item = {
         label: fieldMetadata["caption"],
-        displayValue: column["displayValue"],
+        displayValue: isDate ? column["formattedValue"] : column["displayValue"],
         url: column["url"],
         value: column["value"]
       };


### PR DESCRIPTION
#### Rationale
A user reported that certain dates in the animal history abstract code were incorrect to the hour/minute/seconds.

#### Related Pull Requests

#### Changes
Switched dates to use the formattedValue provided by labkey instead of the full date value. This change removes the hour/minute/seconds time from dates unless they are included in the formatting.