### PR TITLE
Fix for editing weights due to missing object id from restraint rows

### DIFF
--- a/WNPRC_EHR/src/client/weight/query/helpers.ts
+++ b/WNPRC_EHR/src/client/weight/query/helpers.ts
@@ -55,7 +55,7 @@ export const setupRestraintValues = (values: any[], taskId: string): Array<Restr
       Id: value.animalid.value,
       restraintType: value.restraint.value,
       taskid: taskId,
-      objectid: value.restraint.objectid,
+      objectid: value.restraint_objectid.value,
       date: value.date.value
     })
   }


### PR DESCRIPTION
#### Rationale
User [reported](https://ehr.primate.wisc.edu/issues/WNPRC/WNPRC_Units/Research_Services/EHR_Services/Issue_Tracker/details.view?issueId=20910) being unable to edit weights through the react interface

#### Related Pull Requests

#### Changes
Fix the object id so that it is correctly added to the restraints update submission and it can properly find the rows.