### PR TITLE
Test failure fix - use the exact casing of the column name when checking

### DIFF
--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -2792,8 +2792,8 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         DataRegionTable auditTable =  new DataRegionTable("query", this);
         String auditLog = auditTable.getDataAsText(0,"DataChanges");
         Assertions.assertThat(auditLog).as("Audit entry for ehr_billing.invoice")
-                .contains("paymentamountreceived:  \u00BB 1028.95")
-                .contains("balancedue:  \u00BB 0.0");
+                .contains("paymentAmountReceived:  \u00BB 1028.95")
+                .contains("balanceDue:  \u00BB 0.0");
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
Test failure: https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_External_Wnprc_WnprcEhrPostgres_2/3800769

java.lang.AssertionError: [Audit entry for ehr_billing.invoice] 
Expecting actual:
paymentAmountReceived:  » 1028.95
balanceDue:  » 0.0
to contain:
  "paymentamountreceived:  » 1028.95"
...

  at org.labkey.test.tests.wnprc_ehr.WNPRC_EHRTest.testPaymentsReceived(WNPRC_EHRTest.java:2795)
  at org.labkey.test.tests.wnprc_ehr.WNPRC_EHRTest.testBilling(WNPRC_EHRTest.java:1142)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Use the exact casing of the column name when checking
