### PR TITLE
Fix build by using standard version property

### DIFF
--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.google.auth:google-auth-library-oauth2-http:1.19.0",
+            "com.google.auth:google-auth-library-oauth2-http:${googleAuthVersion}",
             "Google Auth Library",
             "Google",
             "https://github.com/googleapis/google-auth-library-java",


### PR DESCRIPTION
#### Rationale
Build started failing due to version mismatch