### PR TITLE
increasing the max_locks_per_transaction

### DIFF
--- a/docker/postgres/postgresql15.conf
+++ b/docker/postgres/postgresql15.conf
@@ -751,9 +751,9 @@ shared_preload_libraries = 'pg_stat_statements'	# (change requires restart)
 #------------------------------------------------------------------------------
 
 #deadlock_timeout = 1s
-#max_locks_per_transaction = 64		# min 10
+max_locks_per_transaction = 128		# min 10
 					# (change requires restart)
-#max_pred_locks_per_transaction = 64	# min 10
+max_pred_locks_per_transaction = 128	# min 10
 					# (change requires restart)
 #max_pred_locks_per_relation = -2	# negative values mean
 					# (max_pred_locks_per_transaction


### PR DESCRIPTION
#### Rationale
Increasing the max locks per transaction  due to a problem with the db backup 

#### Related Pull Requests
none

#### Changes
change to postgresql15.conf file
