### PR TITLE
Remove miscategorized tests from CustomModules suite

### DIFF
--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRCComplianceTrainingTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRCComplianceTrainingTest.java
@@ -3,7 +3,6 @@ package org.labkey.test.tests.wnprc_ehr;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.Locator;
-import org.labkey.test.categories.CustomModules;
 import org.labkey.test.categories.EHR;
 import org.labkey.test.categories.WNPRC_EHR;
 import org.labkey.test.tests.ehr.ComplianceTrainingTest;
@@ -16,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@Category({CustomModules.class, EHR.class, WNPRC_EHR.class})
+@Category({EHR.class, WNPRC_EHR.class})
 public class WNPRCComplianceTrainingTest extends ComplianceTrainingTest implements PostgresOnlyTest
 {
     @Override

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -42,7 +42,6 @@ import org.labkey.test.SortDirection;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.CustomModules;
 import org.labkey.test.categories.EHR;
 import org.labkey.test.categories.WNPRC_EHR;
 import org.labkey.test.components.bootstrap.ModalDialog;
@@ -116,7 +115,7 @@ import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
  * NOTE: EHRApiTest may be a better location for tests designed to test server-side trigger scripts
  * or similar business logic.
  */
-@Category({CustomModules.class, EHR.class, WNPRC_EHR.class})
+@Category({EHR.class, WNPRC_EHR.class})
 public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnlyTest
 {
     public static final String PROJECT_NAME = "WNPRC";

--- a/WNPRC_Virology/test/src/org/labkey/test/tests/wnprc_virology/WNPRC_VirologyTest.java
+++ b/WNPRC_Virology/test/src/org/labkey/test/tests/wnprc_virology/WNPRC_VirologyTest.java
@@ -16,6 +16,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.ModulePropertyValue;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.categories.EHR;
 import org.labkey.test.categories.WNPRC_EHR;
 import org.labkey.test.components.dumbster.EmailRecordTable;
 import org.labkey.test.components.ext4.Window;
@@ -49,7 +50,7 @@ import static org.labkey.test.WebTestHelper.buildRelativeUrl;
 import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
-@Category({WNPRC_EHR.class})
+@Category({EHR.class, WNPRC_EHR.class})
 public class WNPRC_VirologyTest extends ViralLoadAssayTest
 {
 


### PR DESCRIPTION
#### Rationale
EHR tests don't belong in the `CustomModules` suite. They aren't present where we run that suite on TeamCity and the suite runs a bunch of unexpected tests elsewhere.

#### Related Pull Requests
* N/A
