### PR TITLE
Stop passing SecurityPolicy parameter to Role.isApplicable()

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/security/roles/WNPRCEHRFullSubmitterRole.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/security/roles/WNPRCEHRFullSubmitterRole.java
@@ -5,7 +5,6 @@ import org.labkey.api.ehr.security.EHRStartedInsertPermission;
 import org.labkey.api.ehr.security.EHRStartedUpdatePermission;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.roles.AbstractRole;
 import org.labkey.api.security.roles.Role;
@@ -30,7 +29,7 @@ public class WNPRCEHRFullSubmitterRole extends AbstractRole
     }
 
     @Override
-    public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
+    public boolean isApplicable(SecurableResource resource)
     {
         if (resource instanceof Container)
             return ((Container)resource).getActiveModules().contains(ModuleLoader.getInstance().getModule(WNPRC_EHRModule.class));

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/security/roles/WNPRCEHRRequestorSchedulerRole.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/security/roles/WNPRCEHRRequestorSchedulerRole.java
@@ -4,7 +4,6 @@ package org.labkey.wnprc_ehr.security.roles;
 import org.labkey.api.ehr.security.EHRScheduledInsertPermission;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.roles.AbstractRole;
 import org.labkey.api.security.roles.Role;
@@ -31,7 +30,7 @@ public class WNPRCEHRRequestorSchedulerRole extends AbstractRole
     }
 
     @Override
-    public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
+    public boolean isApplicable(SecurableResource resource)
     {
         return resource instanceof Dataset &&
                 ((Dataset)resource).getContainer().getActiveModules().contains(ModuleLoader.getInstance().getModule(WNPRC_EHRModule.class));

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/security/roles/WNPRCFullSubmitterWithReviewerRole.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/security/roles/WNPRCFullSubmitterWithReviewerRole.java
@@ -3,7 +3,6 @@ package org.labkey.wnprc_ehr.security.roles;
 import org.labkey.api.ehr.security.*;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
@@ -70,7 +69,7 @@ public class WNPRCFullSubmitterWithReviewerRole extends AbstractRole {
     }
 
     @Override
-    public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
+    public boolean isApplicable(SecurableResource resource)
     {
         return resource instanceof Dataset &&
                 ((Dataset)resource).getContainer().getActiveModules().contains(ModuleLoader.getInstance().getModule(WNPRC_EHRModule.class));


### PR DESCRIPTION
#### Rationale
No implementation uses this parameter