### PR TITLE
Mark WNPRC_VirologyTest as postgres-only

### DIFF
--- a/WNPRC_Virology/test/src/org/labkey/test/tests/wnprc_virology/WNPRC_VirologyTest.java
+++ b/WNPRC_Virology/test/src/org/labkey/test/tests/wnprc_virology/WNPRC_VirologyTest.java
@@ -27,8 +27,8 @@ import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PasswordUtil;
-import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.PostgresOnlyTest;
 import org.labkey.test.util.RemoteConnectionHelper;
 import org.labkey.test.util.SchemaHelper;
 import org.labkey.test.util.di.DataIntegrationHelper;
@@ -51,7 +51,7 @@ import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({EHR.class, WNPRC_EHR.class})
-public class WNPRC_VirologyTest extends ViralLoadAssayTest
+public class WNPRC_VirologyTest extends ViralLoadAssayTest implements PostgresOnlyTest
 {
 
     public static final String CUSTOM_PROJECT_NAME = "LaboratoryVerifyProject";


### PR DESCRIPTION
#### Rationale
`WNPRC_Virology` module doesn't support SQL Server. The test should match.

#### Related Pull Requests
* #932 

#### Changes
* Mark WNPRC_VirologyTest as postgres-only