### PR TITLE
Drop redundant indices

### DIFF
--- a/wnprc_billing/resources/schemas/dbscripts/postgresql/wnprc_billing-22.000-22.001.sql
+++ b/wnprc_billing/resources/schemas/dbscripts/postgresql/wnprc_billing-22.000-22.001.sql
@@ -1,0 +1,2 @@
+-- Dropping idx_wnprc_billing_groupcategoryassociations_chargegroupname [chargeGroupName] because it overlaps with uq_wnprc_billing_groupcategoryassociations_group_category [chargeGroupName, chargeCategoryId]
+DROP INDEX wnprc_billing.idx_wnprc_billing_groupcategoryassociations_chargegroupname;

--- a/wnprc_billing/src/org/labkey/wnprc_billing/WNPRC_BillingModule.java
+++ b/wnprc_billing/src/org/labkey/wnprc_billing/WNPRC_BillingModule.java
@@ -65,7 +65,7 @@ public class WNPRC_BillingModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.000;
+        return 22.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Redundant indices waste disk space and degrade insert/update/delete performance

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7630

Note: Once merged to develop, I'll immediately backport this change to 25.7.