### PR TITLE
Specify explicit path to version property in parent project since implicit selection is deprecated as of Gradle 9.6.0

### DIFF
--- a/ApiKey/build.gradle
+++ b/ApiKey/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "org.jooq:jooq:${jooqVersion}",
+            "org.jooq:jooq:${project.parent.ext.jooqVersion}",
             "jOOQ",
             "jOOQ.org",
             "https://www.jooq.org/",

--- a/DBUtils/build.gradle
+++ b/DBUtils/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "org.jooq:jooq:${jooqVersion}",
+            "org.jooq:jooq:${project.parent.ext.jooqVersion}",
             "jOOQ",
             "jOOQ.org",
             "https://www.jooq.org/",

--- a/DeviceProxy/build.gradle
+++ b/DeviceProxy/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "org.jooq:jooq:${jooqVersion}",
+            "org.jooq:jooq:${project.parent.ext.jooqVersion}",
             "jOOQ",
             "jOOQ.org",
             "https://www.jooq.org/",

--- a/GoogleDrive/build.gradle
+++ b/GoogleDrive/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.google.http-client:google-http-client:${project.parent.ext.googleHttpClientVersion}",
+            "com.google.http-client:google-http-client:${googleHttpClientVersion}",
             "Google HTTP Client Library for Java",
             "Google",
             "https://developers.google.com/api-client-library/java",

--- a/GoogleDrive/build.gradle
+++ b/GoogleDrive/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.google.api-client:google-api-client:${googleApiClientVersion}",
+            "com.google.api-client:google-api-client:${project.parent.ext.googleApiClientVersion}",
             "Google API Client Library for Java",
             "Google",
             "https://developers.google.com/api-client-library/java",
@@ -25,7 +25,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.google.http-client:google-http-client:${googleHttpClientVersion}",
+            "com.google.http-client:google-http-client:${project.parent.ext.googleHttpClientVersion}",
             "Google HTTP Client Library for Java",
             "Google",
             "https://developers.google.com/api-client-library/java",
@@ -38,7 +38,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.google.apis:google-api-services-drive:${googleApiServiceDriveVersion}",
+            "com.google.apis:google-api-services-drive:${project.parent.ext.googleApiServiceDriveVersion}",
             "Google Drive API Client Library for Java",
             "Google",
             "https://developers.google.com/api-client-library/java/apis/drive/v3",

--- a/WNPRC_Compliance/build.gradle
+++ b/WNPRC_Compliance/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "org.jooq:jooq:${jooqVersion}",
+            "org.jooq:jooq:${project.parent.ext.jooqVersion}",
             "jOOQ",
             "jOOQ.org",
             "https://www.jooq.org/",

--- a/WNPRC_EHR/build.gradle
+++ b/WNPRC_EHR/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.google.api-client:google-api-client:${googleApiClientVersion}",
+            "com.google.api-client:google-api-client:${project.parent.ext.googleApiClientVersion}",
             "Google API Client Library for Java",
             "Google",
             "https://developers.google.com/api-client-library/java",
@@ -53,7 +53,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.google.apis:google-api-services-calendar:${googleApiServicesCalendarVersion}",
+            "com.google.apis:google-api-services-calendar:${project.parent.ext.googleApiServicesCalendarVersion}",
             "Google Calendar API Client Library for Java",
             "Google",
             "https://github.com/googleapis/google-api-java-client-services/tree/master/clients/google-api-services-calendar/v3",


### PR DESCRIPTION
#### Rationale
[Gradle 9.6.0 ](https://docs.gradle.org/9.6.0/release-notes.html)is the latest and it comes with a [deprecation of certain patterns for getting properties](https://docs.gradle.org/9.6.0/release-notes.html#build-authoring-improvements)

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1424

#### Changes
* Change syntax for referencing version property from parent project
