### PR TITLE
Fix the line with cageui_svg_urls to use tab instead of spaces

### DIFF
--- a/WNPRC_EHR/resources/data/lookup_sets.tsv
+++ b/WNPRC_EHR/resources/data/lookup_sets.tsv
@@ -14,7 +14,7 @@ blood_billed_by	Blood Billed By Field Values	value	title
 blood_code_prefixes	Blood Code Prefix Field Values	value
 cageui_item_types	Room Item Type Field Values	value
 cageui_rack_manufacturers	Rack Manufacturer Field Values	value
-cageui_svg_urls SVG URLS Field Values    value
+cageui_svg_urls	SVG URLS Field Values	value
 chemistry_method	Chemistry Method Field Values	value
 chow_types	Chow Types Field Values	value	
 clinpath_collection_method	Clinpath Collection Method Field Values	value	


### PR DESCRIPTION
#### Rationale
cageui_svg_urls line in lookup_sets (added as part of related PR) uses spaces instead of tab causing TC failure:

https://teamcity.labkey.org/buildConfiguration/LabKey_263Release_External_Wnprc_WnprcEhrPostgres2/4068462?expandedTest=build%3A%28id%3A4068462%29%2Cid%3A2000000006

org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for xpath=//div[contains(text(), 'Delete Complete')]

#### Related Pull Requests
* https://github.com/LabKey/wnprc-modules/pull/968

#### Changes
* Use tab
