### PR TITLE
Fix URL being generated for templates

### DIFF
--- a/CageUI/src/client/components/layoutEditor/Editor.tsx
+++ b/CageUI/src/client/components/layoutEditor/Editor.tsx
@@ -752,7 +752,7 @@ const Editor: FC<EditorProps> = ({roomSize}) => {
             window.location.href = ActionURL.buildURL(
                 ActionURL.getController(),
                 'editLayout',
-                ActionURL.getController(),
+                ActionURL.getContainer(),
                 {room: localRoom.name}
             );
         }


### PR DESCRIPTION
## Rationale
Mistakenly used getController in the container portion of a generated URL causing template redirects to go to the wrong URL.

## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- Corrected incorrect container method